### PR TITLE
Update templates for 'reserve' and 'draft'

### DIFF
--- a/config/DOI_IAD2_reserved_template_20200205-mustache.xml
+++ b/config/DOI_IAD2_reserved_template_20200205-mustache.xml
@@ -3,12 +3,12 @@
     {{#dois}}
     <record status="{{status}}"> 
         <title>{{title}}</title>
-        <creators></creators>
         <authors>
             {{#authors}}
              <author>
                 <first_name>{{first_name}}</first_name>
                 <last_name>{{last_name}}</last_name>
+                <full_name>{{full_name}}</full_name>
             </author>
             {{/authors}}
         </authors>
@@ -18,9 +18,9 @@
 
         <related_identifiers>
             <related_identifier>
-                <identifier_type>URL</identifier_type>
+                <identifier_type>URN</identifier_type>
                 <identifier_value>{{related_identifier}}</identifier_value>
-                <relation_type>Cites</relation_type>
+                <relation_type>IsIdenticalTo</relation_type>
             </related_identifier>
         </related_identifiers>        
     </record>

--- a/config/DOI_template_20200407-mustache.xml
+++ b/config/DOI_template_20200407-mustache.xml
@@ -5,11 +5,15 @@
         <authors>
             {{#authors}}
              <author>
+                {{#first_name}}
                 <first_name>{{first_name}}</first_name>
+                {{/first_name}}
+                {{#last_name}}
                 <last_name>{{last_name}}</last_name>
-                {{#full_name.length}}
+                {{/last_name}}
+                {{#full_name}}
                 <full_name>{{full_name}}</full_name>
-                {{/full_name.length}}
+                {{/full_name}}
             </author>
             {{/authors}}
         </authors>
@@ -40,11 +44,15 @@
             {{#editors}}
             <contributor>
                     <email/>
+                    {{#first_name}}
                     <first_name>{{first_name}}</first_name>
+                    {{/first_name}}
+                    {{#last_name}}
                     <last_name>{{last_name}}</last_name>
-                    {{#full_name.length}}
+                    {{/last_name}}
+                    {{#full_name}}
                     <full_name>{{full_name}}</full_name>
-                    {{/full_name.length}}
+                    {{/full_name}}
                     <contributor_type>Editor</contributor_type>
                     <affiliations/>
             </contributor>

--- a/config/DOI_template_20200407-mustache.xml
+++ b/config/DOI_template_20200407-mustache.xml
@@ -2,28 +2,21 @@
 <records>
     <record>
         <title>{{title}}</title>
-        <creators></creators>
         <authors>
             {{#authors}}
              <author>
                 <first_name>{{first_name}}</first_name>
                 <last_name>{{last_name}}</last_name>
+                <full_name>{{full_name}}</full_name>
             </author>
             {{/authors}}
         </authors>
         <publisher>{{publisher}}</publisher>
         <publication_date>{{publication_date}}</publication_date>
         <site_url>{{site_url}}</site_url>
-        <product_type>{{product_type}}</product_type>
+        <product_type>Dataset</product_type>
         <product_type_specific>{{product_type_specific}}</product_type_specific>
         <!-- Product Numbers: insert LIDVID here -->
-        <related_identifiers>
-            <related_identifier>
-            <identifier_type>URL</identifier_type>
-            <identifier_value>{{related_identifier}}</identifier_value>
-            <relation_type>Cites</relation_type>
-            </related_identifier>
-        </related_identifiers>
         <product_nos>{{identifier}}</product_nos>
 
         <description>{{description}}
@@ -47,6 +40,7 @@
                     <email/>
                     <first_name>{{first_name}}</first_name>
                     <last_name>{{last_name}}</last_name>
+                    <full_name>{{full_name}}</full_name>
                     <contributor_type>Editor</contributor_type>
                     <affiliations/>
             </contributor>

--- a/config/DOI_template_20200407-mustache.xml
+++ b/config/DOI_template_20200407-mustache.xml
@@ -7,7 +7,9 @@
              <author>
                 <first_name>{{first_name}}</first_name>
                 <last_name>{{last_name}}</last_name>
+                {{#full_name.length}}
                 <full_name>{{full_name}}</full_name>
+                {{/full_name.length}}
             </author>
             {{/authors}}
         </authors>
@@ -17,7 +19,7 @@
         <product_type>Dataset</product_type>
         <product_type_specific>{{product_type_specific}}</product_type_specific>
         <!-- Product Numbers: insert LIDVID here -->
-        <product_nos>{{identifier}}</product_nos>
+        <product_nos>{{related_identifier}}</product_nos>
 
         <description>{{description}}
         </description>
@@ -40,7 +42,9 @@
                     <email/>
                     <first_name>{{first_name}}</first_name>
                     <last_name>{{last_name}}</last_name>
+                    {{#full_name.length}}
                     <full_name>{{full_name}}</full_name>
+                    {{/full_name.length}}
                     <contributor_type>Editor</contributor_type>
                     <affiliations/>
             </contributor>

--- a/input/DOI_Release_20200727_from_draft.xml
+++ b/input/DOI_Release_20200727_from_draft.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <records>
     <record status='Pending'>
-        <title>InSight Cameras Bundle 2020-07-27-10-42</title>
+        <title>InSight Cameras Bundle</title>
         <authors>
              <author>
                 <first_name>R.</first_name>
@@ -29,8 +29,8 @@
                 retrievable independently. Therefore the Collection record is a high-level description of
                 the overall group of items.
         -->
-        <product_type>Collection</product_type>
-        <product_type_specific>PDS4 Bundle</product_type_specific>
+        <product_type>Dataset</product_type>
+        <product_type_specific>PDS4 Refereed Data Bundle</product_type_specific>
         <!-- Product Numbers: insert LIDVID here -->
         <related_identifiers>
             <related_identifier>
@@ -52,7 +52,7 @@
         <other_identifying_nos></other_identifying_nos>
         <file_extension></file_extension>
         <availability>NSSDCA</availability>
-        <contact_name>PDS OPERATOR</contact_name>
+        <contact_name>PDS Operator</contact_name>
         <contact_org>PDS</contact_org>
         <contact_email>pds-operator@jpl.nasa.gov</contact_email>
         <contact_phone>818.393.7165</contact_phone>
@@ -85,9 +85,9 @@
         </contributors>
         <related_identifiers>
             <related_identifier>
-                <identifier_type>URL</identifier_type>
+                <identifier_type>URN</identifier_type>
                 <identifier_value>urn:nasa:pds:insight_cameras::1.0</identifier_value>
-                <relation_type>Cites</relation_type>
+                <relation_type>IsIdenticalTo</relation_type>
             </related_identifier>
         </related_identifiers>
     </record>

--- a/input/DOI_Release_20200727_from_reserve.xml
+++ b/input/DOI_Release_20200727_from_reserve.xml
@@ -3,11 +3,11 @@
     <id>25901</id>
     <site_url>http://mysite.example.com/link/to/my-dataset-id-25901.html</site_url>
     <site_code>NASA-PDS</site_code>
-    <title>Laboratory Shocked Feldspars Collection</title>
+    <title>Laboratory Shocked Feldspars Bundle</title>
     <doi>10.17189/25901</doi>
     <publication_date>2020-03-11</publication_date>
-    <product_type>Collection</product_type>
-    <product_type_specific>PDS4 Collection</product_type_specific>
+    <product_type>Dataset</product_type>
+    <product_type_specific>PDS4 Refereed Data Bundle</product_type_specific>
     <date_record_added>2020-07-23</date_record_added>
     <date_record_updated>2020-07-23</date_record_updated>
     <authors>
@@ -20,9 +20,9 @@
     <contributors/>
     <related_identifiers>
       <related_identifier>
-        <identifier_type>URL</identifier_type>
+        <identifier_type>URN</identifier_type>
         <identifier_value>urn:nasa:pds:lab_shocked_feldspars::1.0</identifier_value>
-        <relation_type>Cites</relation_type>
+        <relation_type>IsIdenticalTo</relation_type>
       </related_identifier>
     </related_identifiers>
   </record>
@@ -33,8 +33,8 @@
     <title>Laboratory Shocked Feldspars Bundle</title>
     <doi>10.17189/25902</doi>
     <publication_date>2020-03-12</publication_date>
-    <product_type>Collection</product_type>
-    <product_type_specific>PDS4 Bundle</product_type_specific>
+    <product_type>Dataset</product_type>
+    <product_type_specific>PDS4 Refereed Data Bundle</product_type_specific>
     <date_record_added>2020-07-23</date_record_added>
     <date_record_updated>2020-07-23</date_record_updated>
     <authors>
@@ -47,9 +47,9 @@
     <contributors/>
     <related_identifiers>
       <related_identifier>
-        <identifier_type>URL</identifier_type>
+        <identifier_type>URN</identifier_type>
         <identifier_value>urn:nasa:pds:lab_shocked_feldspars_2::1.0</identifier_value>
-        <relation_type>Cites</relation_type>
+        <relation_type>IsIdenticalTo</relation_type>
       </related_identifier>
     </related_identifiers>
   </record>
@@ -60,8 +60,8 @@
     <title>Laboratory Shocked Feldspars Bundle</title>
     <doi>10.17189/25903</doi>
     <publication_date>2020-03-12</publication_date>
-    <product_type>Collection</product_type>
-    <product_type_specific>PDS4 Bundle</product_type_specific>
+    <product_type>Dataset</product_type>
+    <product_type_specific>PDS4 Refereed Data Bundle</product_type_specific>
     <date_record_added>2020-07-23</date_record_added>
     <date_record_updated>2020-07-23</date_record_updated>
     <authors>
@@ -74,9 +74,9 @@
     <contributors/>
     <related_identifiers>
       <related_identifier>
-        <identifier_type>URL</identifier_type>
+        <identifier_type>URN</identifier_type>
         <identifier_value>urn:nasa:pds:lab_shocked_feldspars_3::1.0</identifier_value>
-        <relation_type>Cites</relation_type>
+        <relation_type>IsIdenticalTo</relation_type>
       </related_identifier>
     </related_identifiers>
   </record>

--- a/pds_doi_core/input/pds4_util.py
+++ b/pds_doi_core/input/pds4_util.py
@@ -64,7 +64,7 @@ class DOIPDS4LabelUtil:
                   description=pds4_fields['description'],
                   publication_date=self.get_publication_date(pds4_fields),
                   product_type=product_type,
-                  product_type_specific= "PDS4 " + product_type,
+                  product_type_specific= "PDS4 Refereed Data " + product_type,
                   related_identifier=pds4_fields['lid'] + '::' + pds4_fields['vid'],
                   site_url=site_url,
                   authors=self.get_author_names(pds4_fields['authors'].split(',')),
@@ -119,8 +119,10 @@ class DOIPDS4LabelUtil:
                                 'last_name': split_full_name[first_last_name_order[1]].strip()})
             else:
                 logger.warning(f"author first name not found for [{full_name}]")
-                persons.append({'first_name': '',
-                                'last_name': full_name.strip()})
+                # Deleted the first_name field as an empty string.
+                # OSTI does not like for any fields to be empty string.
+                # If cannot parse first_name or last_name, create full_name instead.
+                persons.append({'full_name': full_name.strip()}) 
 
         return persons
 

--- a/pds_doi_core/outputs/osti_web_parser.py
+++ b/pds_doi_core/outputs/osti_web_parser.py
@@ -59,23 +59,13 @@ class DOIOstiWebParser:
                     logger.error(f"ERROR OSTI RECORD {element.text}")
                     continue
                 else:
-                    # It is important to check if either 'URL' or 'URN' are in the element.xpath for related_identifiers before accessing it
-                    # otherwise an index error will occur.
-                    if element.xpath("related_identifiers/related_identifier[./identifier_type='URL']"):
-                        identifier_parsed = element.xpath("related_identifiers/related_identifier[./identifier_type='URL']/identifier_value")[0].text
-                    elif element.xpath("related_identifiers/related_identifier[./identifier_type='URN']"):
-
-                        identifier_parsed = element.xpath("related_identifiers/related_identifier[./identifier_type='URN']/identifier_value")[0].text
-                    else:
-                        raise InputFormatException("Cannot find identifier_value.  Expecting either URL or URN for identifier_type")
-
                     # The following 4 fields were deleted from constructor of Doi to inspect individually since the code was failing:
                     #     ['id','doi','date_record_added',date_record_updated']
                     doi = Doi(title=element.xpath('title')[0].text,
                               publication_date=element.xpath('publication_date')[0].text,
                               product_type=element.xpath('product_type')[0].text,
                               product_type_specific=element.xpath('product_type_specific')[0].text,
-                              related_identifier=identifier_parsed,
+                              related_identifier=element.xpath("related_identifiers/related_identifier[./identifier_type='URN']/identifier_value")[0].text,
                               status=status)
 
                     # Not all responses have the 'id' or 'doi' fields.

--- a/pds_doi_core/outputs/osti_web_parser.py
+++ b/pds_doi_core/outputs/osti_web_parser.py
@@ -59,13 +59,23 @@ class DOIOstiWebParser:
                     logger.error(f"ERROR OSTI RECORD {element.text}")
                     continue
                 else:
+                    # It is important to check if either 'URL' or 'URN' are in the element.xpath for related_identifiers before accessing it
+                    # otherwise an index error will occur.
+                    if element.xpath("related_identifiers/related_identifier[./identifier_type='URL']"):
+                        identifier_parsed = element.xpath("related_identifiers/related_identifier[./identifier_type='URL']/identifier_value")[0].text
+                    elif element.xpath("related_identifiers/related_identifier[./identifier_type='URN']"):
+
+                        identifier_parsed = element.xpath("related_identifiers/related_identifier[./identifier_type='URN']/identifier_value")[0].text
+                    else:
+                        raise InputFormatException("Cannot find identifier_value.  Expecting either URL or URN for identifier_type")
+
                     # The following 4 fields were deleted from constructor of Doi to inspect individually since the code was failing:
                     #     ['id','doi','date_record_added',date_record_updated']
                     doi = Doi(title=element.xpath('title')[0].text,
                               publication_date=element.xpath('publication_date')[0].text,
                               product_type=element.xpath('product_type')[0].text,
                               product_type_specific=element.xpath('product_type_specific')[0].text,
-                              related_identifier=element.xpath("related_identifiers/related_identifier[./identifier_type='URL']/identifier_value")[0].text,
+                              related_identifier=identifier_parsed,
                               status=status)
 
                     # Not all responses have the 'id' or 'doi' fields.

--- a/pds_doi_core/util/doi_validator.py
+++ b/pds_doi_core/util/doi_validator.py
@@ -72,8 +72,10 @@ class DOIValidator:
             Otherwise we raise a warning.
         """
         product_type_specific_split = doi.product_type_specific.split(' ')
-        product_type_specific_suffix = product_type_specific_split[1] if len(product_type_specific_split)>1 else '<<< no product specfic type found >>> '
+        # The suffix should be the last field in the product_type_specific so if it has many tokens, check the last one.
+        product_type_specific_suffix = product_type_specific_split[-1] if len(product_type_specific_split)>1 else '<<< no product specfic type found >>> '
 
+        logger.debug(f"product_type_specific_suffix: {product_type_specific_suffix}, doi.title: {doi.title}")
         if not product_type_specific_suffix.lower() in doi.title.lower():
             logger.debug(f"DOI with lidvid {doi.related_identifier} title {doi.title} does not match product type {doi.product_type.lower()}. Product type should be in the title")
             raise TitleDoesNotMatchProductTypeException(f"DOI with lidvid {doi.related_identifier} title {doi.title} does not match product type {doi.product_type.lower()}. Product type should be in the title")

--- a/pds_doi_core/util/emailer.py
+++ b/pds_doi_core/util/emailer.py
@@ -55,6 +55,7 @@ class Emailer:
             smtpObj = smtplib.SMTP(self.m_localhost,self.m_email_port)
             smtpObj.sendmail(sender, receivers, out_message)
             logger.debug(f"Successfully sent email to {receivers}")
+            smtpObj.quit() # Terminate the SMTP session and close the connection.
         except OSError:
             logger.error("OSError:Error: unable to send email")
             logger.debug(f"subject,message_body {subject,message_body}")
@@ -117,6 +118,7 @@ class Emailer:
             smtpObj = smtplib.SMTP(self.m_localhost,self.m_email_port)
             smtpObj.send_message(message)
             logger.debug(f"Successfully sent email to {message['To']}")
+            smtpObj.quit() # Terminate the SMTP session and close the connection.
         except OSError:
             logger.error("OSError:Error: unable to send email")
             logger.error("subject,message_body {msg['Subject'],msg.get_body('plain')}")


### PR DESCRIPTION
Pull request to close two issues #55 and #58:

https://github.com/NASA-PDS/pds-doi-service/issues/55 Update default DOI metadata according to changes in requirements
https://github.com/NASA-PDS/pds-doi-service/issues/58 create full_name when first/last name cannot be parsed

**Test Data and/or Report**

All the unit tests can be ran with the following commands.  Some test data are already in git and some are external URL resources.   They all are referred in the unit tests.

If the test is successful, the number of tests ran and 'OK' on the last line of output:

python3 pds_doi_core/actions/test/draft_test.py
python3 pds_doi_core/actions/test/list_test.py
python3 pds_doi_core/actions/test/check_test.py
python3 pds_doi_core/actions/test/reserve_test.py
python3 pds_doi_core/actions/test/release_test.py
python3 pds_doi_core/util/test/doi_validator_test.py

