### PR TITLE
Changes to support issue #70: Add catching of warning exceptions from…

### DIFF
--- a/pds_doi_core/actions/test/draft_test.py
+++ b/pds_doi_core/actions/test/draft_test.py
@@ -18,7 +18,7 @@ def create_temporary_output_file(doi_label,filename):
 
 class MyTestCase(unittest.TestCase):
     db_name = 'doi_temp.db'
-    # Because validation has been added to each action, the force_flag=True is required as the command line is not parsed for unit test.
+    # Because validation has been added to each action, the force=True is required as the command line is not parsed for unit test.
 
     @classmethod
     def setUp(self):
@@ -43,21 +43,21 @@ class MyTestCase(unittest.TestCase):
         logger.info("test local dir with one file")
         osti_doi = self._action.run(input='input/draft_dir_one_file',
                               node='img',
-                              submitter='my_user@my_node.gov',force_flag=True)
+                              submitter='my_user@my_node.gov',force=True)
         logger.info(osti_doi)
 
     def test_local_dir_two_files(self):
         logger.info("test local dir with two files")
         osti_doi = self._action.run(input='input/draft_dir_two_files',
                               node='img',
-                              submitter='my_user@my_node.gov',force_flag=True)
+                              submitter='my_user@my_node.gov',force=True)
         logger.info(osti_doi)
 
     def test_local_bundle(self):
         logger.info("test local bundle")
         osti_doi = self._action.run(input='input/bundle_in_with_contributors.xml',
                               node='img',
-                              submitter='my_user@my_node.gov',force_flag=True)
+                              submitter='my_user@my_node.gov',force=True)
         logger.info(osti_doi)
 
     def test_remote_bundle(self):
@@ -65,41 +65,41 @@ class MyTestCase(unittest.TestCase):
         osti_doi = self._action.run(
                                     input='https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/bundle.xml',
                                     node='img',
-                                    submitter='my_user@my_node.gov',force_flag=True)
+                                    submitter='my_user@my_node.gov',force=True)
         logger.info(osti_doi)
-        create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_bundle_doi.xml'))
+        #create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_bundle_doi.xml'))
 
     def test_remote_collection(self):
         logger.info("test remote collection")
         osti_doi = self._action.run(
                                     input='https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/data/collection_data.xml',
-                                    node='img', submitter='my_user@my_node.gov',force_flag=True)
+                                    node='img', submitter='my_user@my_node.gov',force=True)
         logger.info(osti_doi)
-        create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_datacoll_doi.xml'))
+        #create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_datacoll_doi.xml'))
 
     def test_remote_browse_collection(self):
         logger.info("test remote browse collection")
         osti_doi = self._action.run(
                                     input='https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/browse/collection_browse.xml',
-                                    node='img', submitter='my_user@my_node.gov',force_flag=True)
+                                    node='img', submitter='my_user@my_node.gov',force=True)
         logger.info(osti_doi)
-        create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_browsecoll_doi.xml'))
+        #create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_browsecoll_doi.xml'))
 
     def test_remote_calibration_collection(self):
         logger.info("test remote calibration collection")
         osti_doi = self._action.run(
                                     input='https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/calibration/collection_calibration.xml',
-                                    node='img', submitter='my_user@my_node.gov',force_flag=True)
+                                    node='img', submitter='my_user@my_node.gov',force=True)
         logger.info(osti_doi)
-        create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_calibcoll_doi.xml'))
+        #create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_calibcoll_doi.xml'))
 
     def test_remote_document_collection(self):
         logger.info("test remote document collection")
         osti_doi = self._action.run(
                                     input='https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/document/collection_document.xml',
-                                    node='img', submitter='my_user@my_node.gov',force_flag=True)
+                                    node='img', submitter='my_user@my_node.gov',force=True)
         logger.info(osti_doi)
-        create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_docucoll_doi.xml'))
+        #create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_docucoll_doi.xml'))
 
 
 if __name__ == '__main__':

--- a/pds_doi_core/actions/test/release_test.py
+++ b/pds_doi_core/actions/test/release_test.py
@@ -15,10 +15,14 @@ class MyTestCase(unittest.TestCase):
     # to demonstrate that they have new status of 'Pending' or 'Registered'.  If for some reason the server has been wiped clean, this unit test will still run
     # but won't show any status changed to 'Registered'.
     #
-    # Because validation has been added to each action, the force_flag=True is required as the command line is not parsed for unit test.
+    # Because validation has been added to each action, the force=True is required as the command line is not parsed for unit test.
 
     db_name = 'doi_temp.db'
     logger.info("Creating test artifact database file {self.db_name}")
+    # Remove db_name if exist to have a fresh start otherwise exception will be raised about using existing lidvid.
+    if os.path.isfile(db_name):
+        os.remove(db_name)
+        logger.info(f"Removed test artifact database file {db_name}")
 
     # Release some DOIs.
     # Move instantation of DOICoreActionRelease() object inside tests since the temporary file is removed after each test
@@ -39,7 +43,7 @@ class MyTestCase(unittest.TestCase):
         # Instantiate DOICoreActionRelease() here so a new database file is created and removed for each test.
         # The setUp() function is called per test.
         logger.info("test release of document from 'reserve' action.  This test would only work if the authentication for OSTI has been set up and DOIs exist.")
-        result_list = self._action.run(input='input/DOI_Release_20200727_from_reserve.xml',node='img',submitter='Qui.T.Chau@jpl.nasa.gov',force_flag=True)
+        result_list = self._action.run(input='input/DOI_Release_20200727_from_reserve.xml',node='img',submitter='Qui.T.Chau@jpl.nasa.gov',force=True)
 
         logger.info(result_list)
         # The tearDown() function is called per test.
@@ -49,7 +53,7 @@ class MyTestCase(unittest.TestCase):
         # The setUp() function is called per test.
         logger.info("test release of document from 'release' output.  This test would only work if the authentication for OSTI has been set up and DOIs exist.")
         result_list = []
-        result_list = self._action.run(input='input/DOI_Release_20200727_from_draft.xml',node='img',submitter='Qui.T.Chau@jpl.nasa.gov',force_flag=True)
+        result_list = self._action.run(input='input/DOI_Release_20200727_from_draft.xml',node='img',submitter='Qui.T.Chau@jpl.nasa.gov',force=True)
 
         logger.info(result_list)
         # The tearDown() function is called per test.

--- a/pds_doi_core/actions/test/reserve_test.py
+++ b/pds_doi_core/actions/test/reserve_test.py
@@ -15,7 +15,7 @@ class MyTestCase(unittest.TestCase):
     # Due to addition of validation of existing 'title', 'lidvid' and 'doi' fields from local database,
     # the DOICoreActionReserve must be instantiated per test and the tear down per test as well to remove temporary database.
 
-    # Because validation has been added to each action, the force_flag=True is required as the command line is not parsed for unit test.
+    # Because validation has been added to each action, the force=True is required as the command line is not parsed for unit test.
     db_name = 'doi_temp.db'
 
     def setUp(self):
@@ -37,7 +37,7 @@ class MyTestCase(unittest.TestCase):
         self._action.run(
             input='input/DOI_Reserved_GEO_200318_with_corrected_identifier.xlsx',
             node='img', submitter='my_user@my_node.gov',
-            dry_run=True,force_flag=True)
+            dry_run=True,force=True)
 
         # The tearDown() function is called per test.
 
@@ -49,7 +49,7 @@ class MyTestCase(unittest.TestCase):
         self._action.run(
             input='input/DOI_Reserved_GEO_200318_with_corrected_identifier.xlsx',
             node='img', submitter='my_user@my_node.gov',
-            dry_run=True,force_flag=True)
+            dry_run=True,force=True)
 
         # The tearDown() function is called per test.
 
@@ -60,7 +60,7 @@ class MyTestCase(unittest.TestCase):
         osti_doi = self._action.run(
             input='input/DOI_Reserved_GEO_200318.csv',
             node='img', submitter='my_user@my_node.gov',
-            dry_run=True,force_flag=True)
+            dry_run=True,force=True)
         logger.info(osti_doi)
 
     def test_reserve_csv_and_submit(self):
@@ -68,7 +68,7 @@ class MyTestCase(unittest.TestCase):
         osti_doi = self._action.run(
             input='input/DOI_Reserved_GEO_200318.csv',
             node='img', submitter='my_user@my_node.gov',
-            dry_run=False,force_flag=True)
+            dry_run=False,force=True)
         logger.info(osti_doi)
 
         # The tearDown() function is called per test.

--- a/pds_doi_core/input/exceptions.py
+++ b/pds_doi_core/input/exceptions.py
@@ -31,3 +31,6 @@ class CriticalDOIException(Exception):
 class WarningDOIException(Exception):
     pass
 
+class SiteURNotExistException(Exception):
+    pass
+

--- a/pds_doi_core/input/input_util.py
+++ b/pds_doi_core/input/input_util.py
@@ -59,8 +59,21 @@ class DOIInputUtil:
         doi_records = []
 
         for index, row in xl_sheet.iterrows():
+            logger.debug(f"row {row}")
+            # It is possible that the length of row['publication_date'] is more than needed, we only need to get the first 10 characters
+            #   '2020-08-01' from '2020-08-01 00:00:00' 
+            if len(row['publication_date']) >= 10:
+                # It is possible that the format provided is not expected, put try/except clause to catch that.
+                try:
+                    publication_date_value =  datetime.strptime(row['publication_date'][0:10], '%Y-%m-%d')
+                except Exception:
+                    logger.error("Expecting publication_date [" + row['publication_date'] + "] with format YYYY-mm-dd")
+                    raise InputFormatException("Expecting publication_date [" + row['publication_date'] + "] with format YYYY-mm-dd")
+            else:
+                raise InputFormatException("Expecting publication_date to be at least 10 characters: [" + row['publication_date'] + "]")
+
             doi = Doi(title=row['title'],
-                      publication_date=datetime.fromisoformat(row['publication_date']),
+                      publication_date=publication_date_value,
                       product_type='Collection',
                       product_type_specific=row['product_type_specific'],
                       related_identifier=row['related_resource'],


### PR DESCRIPTION
Pull request to close issue #70.

This issue to check for landing pages in site_url field before releasing a DOI.

Running the release test with:

python3 pds_doi_core/cmd/pds_doi_cmd.py release -n img -s Qui.T.Chau@jpl.nasa.gov -i input/DOI_Release_20200727_from_reserve.xml

there will be 3 warn exceptions to alert the user that the site_url are not quite online yet to allow the user to fix them.

pds_doi_core.input.exceptions.WarningDOIException: SiteURNotExistException:site_url http://mysite.example.com/link/to/my-dataset-id-25901.html not exist, SiteURNotExistException:site_url http://mysite.example.com/link/to/my-dataset-id-25902.html not exist, SiteURNotExistException:site_url http://mysite.example.com/link/to/my-dataset-id-25903.html not exist

Running the test again with --force will allow the DOI to be released even though the site_url are not online.

python3 pds_doi_core/cmd/pds_doi_cmd.py release -n img -s Qui.T.Chau@jpl.nasa.gov -i input/DOI_Release_20200727_from_reserve.xml --force
