### PR TITLE
DOI Service API Release Endpoint

### DIFF
--- a/pds_doi_service/api/models/doi_record.py
+++ b/pds_doi_service/api/models/doi_record.py
@@ -12,7 +12,7 @@ class DoiRecord(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, doi: str = None, lid: str = None, vid: str = None,
+    def __init__(self, doi: str = None, lidvid: str = None,
                  submitter: str = None, status: str = None,
                  creation_date: datetime = None, update_date: datetime = None,
                  record: str = None, message: str = None):  # noqa: E501
@@ -20,10 +20,8 @@ class DoiRecord(Model):
 
         :param doi: The doi of this DoiRecord.  # noqa: E501
         :type doi: str
-        :param lid: The lid of this DoiRecord.  # noqa: E501
-        :type lid: str
-        :param vid: The vid of this DoiRecord.  # noqa: E501
-        :type vid: str
+        :param lidvid: The lidvid of this DoiRecord.  # noqa: E501
+        :type lidvid: str
         :param submitter: The submitter of this DoiRecord.  # noqa: E501
         :type submitter: str
         :param status: The status of this DoiRecord.  # noqa: E501
@@ -39,8 +37,7 @@ class DoiRecord(Model):
         """
         self.swagger_types = {
             'doi': str,
-            'lid': str,
-            'vid': str,
+            'lidvid': str,
             'submitter': str,
             'status': str,
             'creation_date': datetime,
@@ -51,8 +48,7 @@ class DoiRecord(Model):
 
         self.attribute_map = {
             'doi': 'doi',
-            'lid': 'lid',
-            'vid': 'vid',
+            'lidvid': 'lidvid',
             'submitter': 'submitter',
             'status': 'status',
             'creation_date': 'creation_date',
@@ -61,8 +57,7 @@ class DoiRecord(Model):
             'message': 'message'
         }
         self._doi = doi
-        self._lid = lid
-        self._vid = vid
+        self._lidvid = lidvid
         self._submitter = submitter
         self._status = status
         self._creation_date = creation_date
@@ -103,46 +98,25 @@ class DoiRecord(Model):
         self._doi = doi
 
     @property
-    def lid(self) -> str:
-        """Gets the lid of this DoiRecord.
+    def lidvid(self) -> str:
+        """Gets the lidvid of this DoiRecord.
 
 
-        :return: The lid of this DoiRecord.
+        :return: The lidvid of this DoiRecord.
         :rtype: str
         """
-        return self._lid
+        return self._lidvid
 
-    @lid.setter
-    def lid(self, lid: str):
-        """Sets the lid of this DoiRecord.
+    @lidvid.setter
+    def lidvid(self, lidvid: str):
+        """Sets the lidvid of this DoiRecord.
 
 
-        :param lid: The lid of this DoiRecord.
-        :type lid: str
+        :param lidvid: The lidvid of this DoiRecord.
+        :type lidvid: str
         """
 
-        self._lid = lid
-
-    @property
-    def vid(self) -> str:
-        """Gets the vid of this DoiRecord.
-
-
-        :return: The vid of this DoiRecord.
-        :rtype: str
-        """
-        return self._vid
-
-    @vid.setter
-    def vid(self, vid: str):
-        """Sets the vid of this DoiRecord.
-
-
-        :param vid: The vid of this DoiRecord.
-        :type vid: str
-        """
-
-        self._vid = vid
+        self._lidvid = lidvid
 
     @property
     def submitter(self) -> str:

--- a/pds_doi_service/api/models/doi_summary.py
+++ b/pds_doi_service/api/models/doi_summary.py
@@ -12,17 +12,15 @@ class DoiSummary(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, doi: str = None, lid: str = None, vid: str = None,
+    def __init__(self, doi: str = None, lidvid: str = None,
                  submitter: str = None, status: str = None,
                  creation_date: datetime = None, update_date: datetime = None):  # noqa: E501
         """DoiSummary - a model defined in Swagger
 
         :param doi: The doi of this DoiSummary.  # noqa: E501
         :type doi: str
-        :param lid: The lid of this DoiSummary.  # noqa: E501
-        :type lid: str
-        :param vid: The vid of this DoiSummary.  # noqa: E501
-        :type vid: str
+        :param lidvid: The lidvid of this DoiSummary.  # noqa: E501
+        :type lidvid: str
         :param submitter: The submitter of this DoiSummary.  # noqa: E501
         :type submitter: str
         :param status: The status of this DoiSummary.  # noqa: E501
@@ -34,8 +32,7 @@ class DoiSummary(Model):
         """
         self.swagger_types = {
             'doi': str,
-            'lid': str,
-            'vid': str,
+            'lidvid': str,
             'submitter': str,
             'status': str,
             'creation_date': datetime,
@@ -44,16 +41,14 @@ class DoiSummary(Model):
 
         self.attribute_map = {
             'doi': 'doi',
-            'lid': 'lid',
-            'vid': 'vid',
+            'lidvid': 'lidvid',
             'submitter': 'submitter',
             'status': 'status',
             'creation_date': 'creation_date',
             'update_date': 'update_date'
         }
         self._doi = doi
-        self._lid = lid
-        self._vid = vid
+        self._lidvid = lidvid
         self._submitter = submitter
         self._status = status
         self._creation_date = creation_date
@@ -92,46 +87,25 @@ class DoiSummary(Model):
         self._doi = doi
 
     @property
-    def lid(self) -> str:
-        """Gets the lid of this DoiSummary.
+    def lidvid(self) -> str:
+        """Gets the lidvid of this DoiSummary.
 
 
-        :return: The lid of this DoiSummary.
+        :return: The lidvid of this DoiSummary.
         :rtype: str
         """
-        return self._lid
+        return self._lidvid
 
-    @lid.setter
-    def lid(self, lid: str):
-        """Sets the lid of this DoiSummary.
+    @lidvid.setter
+    def lidvid(self, lidvid: str):
+        """Sets the lidvid of this DoiSummary.
 
 
-        :param lid: The lid of this DoiSummary.
-        :type lid: str
+        :param lidvid: The lidvid of this DoiSummary.
+        :type lidvid: str
         """
 
-        self._lid = lid
-
-    @property
-    def vid(self) -> str:
-        """Gets the vid of this DoiSummary.
-
-
-        :return: The vid of this DoiSummary.
-        :rtype: str
-        """
-        return self._vid
-
-    @vid.setter
-    def vid(self, vid: str):
-        """Sets the vid of this DoiSummary.
-
-
-        :param vid: The vid of this DoiSummary.
-        :type vid: str
-        """
-
-        self._vid = vid
+        self._lidvid = lidvid
 
     @property
     def submitter(self) -> str:

--- a/pds_doi_service/api/swagger/swagger.yaml
+++ b/pds_doi_service/api/swagger/swagger.yaml
@@ -129,6 +129,16 @@ paths:
         explode: true
         schema:
           type: string
+      - name: force
+        in: query
+        description: If true, forces a reserve request to completion, ignoring any
+          warnings encountered. Has no effect for draft requests.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: boolean
+          default: false
       requestBody:
         description: Payload containing one or more labels in JSON or XML (PDS4) format.
           Required for reserve requests, but optional for draft.
@@ -266,31 +276,32 @@ paths:
         "500":
           description: Internal error
       x-openapi-router-controller: pds_doi_service.api.controllers.dois_controller
-  /dois/{doi_prefix}/{doi_suffix}/release:
+  /dois/{lidvid}/release:
     post:
       tags:
       - dois
       description: Move a DOI record from draft/reserve status to "release".
       operationId: post_release_doi
       parameters:
-      - name: doi_prefix
+      - name: lidvid
         in: path
-        description: The prefix of the DOI identifier.
+        description: The LIDVID associated with the record to release.
         required: true
         style: simple
         explode: false
         schema:
           type: string
-        example: "10.17189"
-      - name: doi_suffix
-        in: path
-        description: The suffix of the DOI identifier
-        required: true
-        style: simple
-        explode: false
+        example: 'urn:nasa:pds:lab_shocked_feldspars::1.0'
+      - name: force
+        in: query
+        description: If true, forces a release request to completion, ignoring any
+          warnings encountered.
+        required: false
+        style: form
+        explode: true
         schema:
-          type: string
-        example: "21734"
+          type: boolean
+          default: false
       responses:
         "200":
           description: Success
@@ -335,9 +346,7 @@ components:
       properties:
         doi:
           type: string
-        lid:
-          type: string
-        vid:
+        lidvid:
           type: string
         submitter:
           type: string
@@ -350,9 +359,8 @@ components:
           type: string
           format: date-time
       example:
-        vid: 1.0
         submitter: my.email@node.gov
-        lid: urn:nasa:pds:lab_shocked_feldspars
+        lidvid: urn:nasa:pds:lab_shocked_feldspars::1.0
         creation_date: 2000-08-22T12:00:00.000+00:00
         update_date: 2001-01-23T04:56:07.000+00:00
         doi: 10.17189/21734

--- a/pds_doi_service/api/test/data/draft_osti_record.xml
+++ b/pds_doi_service/api/test/data/draft_osti_record.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<records>
+    <record status='Pending'>
+        <id></id>
+        <title>InSight Cameras Bundle 1.1</title>
+        <sponsoring_organization>National Aeronautics and Space Administration (NASA)</sponsoring_organization>
+        <accession_number>urn:nasa:pds:insight_cameras::1.1</accession_number>
+        <publisher>NASA Planetary Data System</publisher>
+        <availability>NASA Planetary Data System</availability>
+        <publication_date>2019-01-01</publication_date>
+        <country>USA</country>
+        <description>InSight Cameras Experiment Data Record (EDR) and Reduced Data Record (RDR) Data Products
+        </description>
+        <site_url>https://pds.nasa.gov/ds-view/pds/viewBundle.jsp?identifier=urn%3Anasa%3Apds%3Ainsight_cameras&amp;version=1.1</site_url>
+        <product_type>Dataset</product_type>
+        <product_type_specific>PDS4 Refereed Data Bundle</product_type_specific>
+        <date_record_added>2020-11-10</date_record_added>
+        <keywords>PDS; PDS4; raw; context; lander; science; insight; reduced; rdr; data; edr; camera; product; Engineering; experiment; mar; record; deployment</keywords>
+        <authors>
+             <author>
+                <last_name>Deen</last_name>
+                <first_name>R.</first_name>
+            </author>
+             <author>
+                <last_name>Abarca</last_name>
+                <first_name>H.</first_name>
+            </author>
+             <author>
+                <last_name>Zamani</last_name>
+                <first_name>P.</first_name>
+            </author>
+             <author>
+                <last_name>Maki</last_name>
+                <first_name>J.</first_name>
+            </author>
+        </authors>
+        <contributors>
+            <contributor>
+                <full_name>Planetary Data System: Engineering Node</full_name>
+                <contributor_type>DataCurator</contributor_type>
+            </contributor>
+        </contributors>
+        <!--product_nos>urn:nasa:pds:insight_cameras::1.1</product_nos-->
+        <contact_name>PDS Operator</contact_name>
+        <contact_org>PDS</contact_org>
+        <contact_email>pds-operator@jpl.nasa.gov</contact_email>
+        <contact_phone>818.393.7165</contact_phone>
+    </record>
+</records>
+

--- a/pds_doi_service/api/test/data/error_osti_record.xml
+++ b/pds_doi_service/api/test/data/error_osti_record.xml
@@ -1,0 +1,43 @@
+<records total="2" errors="1">
+  <record status="Error" index="1">
+    <site_code>NASA-PDS</site_code>
+    <errors>
+      <error>Title is required.</error>
+      <error>A publication date is required.</error>
+      <error>A site URL is required.</error>
+      <error>A product type is required.</error>
+      <error>A specific product type is required for non-dataset types.</error>
+    </errors>
+  </record>
+  <record status="Reserved" index="2">
+    <id>28606</id>
+    <site_code>NASA-PDS</site_code>
+    <title>Laboratory Shocked Feldspars Bundle</title>
+    <sponsoring_organization>National Aeronautics and Space Administration (NASA)</sponsoring_organization>
+    <accession_number>urn:nasa:pds:lab_shocked_feldspars</accession_number>
+    <doi>10.17189/28606</doi>
+    <publisher>NASA Planetary Data System</publisher>
+    <publication_date>2020-11-05</publication_date>
+    <site_url>N/A</site_url>
+    <product_type>Collection</product_type>
+    <product_type_specific>PDS4 Bundle</product_type_specific>
+    <date_record_added>2020-11-05</date_record_added>
+    <date_record_updated>2020-11-05</date_record_updated>
+    <keywords>PDS; PDS4;</keywords>
+    <authors>
+      <author>
+        <first_name>Reginald P.</first_name>
+        <last_name>Linux</last_name>
+        <affiliations/>
+      </author>
+    </authors>
+    <contributors>
+      <contributor>
+        <full_name>Planetary Data System: Cartography and Imaging Sciences Discipline Node</full_name>
+        <contributor_type>DataCurator</contributor_type>
+        <affiliations/>
+      </contributor>
+    </contributors>
+    <related_identifiers/>
+  </record>
+</records>

--- a/pds_doi_service/api/test/data/output.xml
+++ b/pds_doi_service/api/test/data/output.xml
@@ -1,0 +1,1 @@
+draft_osti_record.xml

--- a/pds_doi_service/api/test/data/release_osti_record.xml
+++ b/pds_doi_service/api/test/data/release_osti_record.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<records>
+    <record status='Released'>
+        <doi>10.17189/21734</doi>
+        <title>InSight Cameras Bundle 1.1</title>
+        <sponsoring_organization>National Aeronautics and Space Administration (NASA)</sponsoring_organization>
+        <accession_number>urn:nasa:pds:insight_cameras::1.1</accession_number>
+        <publisher>NASA Planetary Data System</publisher>
+        <availability>NASA Planetary Data System</availability>
+        <publication_date>2019-01-01</publication_date>
+        <country>USA</country>
+        <description>InSight Cameras Experiment Data Record (EDR) and Reduced Data Record (RDR) Data Products
+        </description>
+        <site_url>https://pds.nasa.gov/ds-view/pds/viewBundle.jsp?identifier=urn%3Anasa%3Apds%3Ainsight_cameras&amp;version=1.1</site_url>
+        <product_type>Dataset</product_type>
+        <product_type_specific>PDS4 Refereed Data Bundle</product_type_specific>
+        <date_record_added>2020-11-10</date_record_added>
+        <keywords>PDS; PDS4; raw; context; lander; science; insight; reduced; rdr; data; edr; camera; product; Engineering; experiment; mar; record; deployment</keywords>
+        <authors>
+             <author>
+                <last_name>Deen</last_name>
+                <first_name>R.</first_name>
+            </author>
+             <author>
+                <last_name>Abarca</last_name>
+                <first_name>H.</first_name>
+            </author>
+             <author>
+                <last_name>Zamani</last_name>
+                <first_name>P.</first_name>
+            </author>
+             <author>
+                <last_name>Maki</last_name>
+                <first_name>J.</first_name>
+            </author>
+        </authors>
+        <contributors>
+            <contributor>
+                <full_name>Planetary Data System: Engineering Node</full_name>
+                <contributor_type>DataCurator</contributor_type>
+            </contributor>
+        </contributors>
+        <!--product_nos>urn:nasa:pds:insight_cameras::1.1</product_nos-->
+        <contact_name>PDS Operator</contact_name>
+        <contact_org>PDS</contact_org>
+        <contact_email>pds-operator@jpl.nasa.gov</contact_email>
+        <contact_phone>818.393.7165</contact_phone>
+    </record>
+</records>
+

--- a/pds_doi_service/api/test/data/reserve_osti_record.xml
+++ b/pds_doi_service/api/test/data/reserve_osti_record.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<records>
+    <record status="reserved_not_submitted"> 
+        <id></id>
+        <title>Laboratory Shocked Feldspars Bundle</title>
+        <sponsoring_organization>National Aeronautics and Space Administration (NASA)</sponsoring_organization>
+        <accession_number>urn:nasa:pds:lab_shocked_feldspars</accession_number>
+        <publisher>NASA Planetary Data System</publisher>
+        <availability></availability>
+        <publication_date>2020-11-10</publication_date>
+        <site_url>N/A</site_url>
+        <product_type>Collection</product_type>
+        <product_type_specific>PDS4 Bundle</product_type_specific>
+        <date_record_added>2020-11-10</date_record_added>
+        <keywords>PDS; PDS4;</keywords>
+        <authors>
+             <author>
+                <last_name>Johnson</last_name>
+                <first_name>J. R.</first_name>
+            </author>
+        </authors>
+        <contributors>
+            <contributor>
+                <full_name>Planetary Data System: Cartography and Imaging Sciences Discipline Node</full_name>
+                <contributor_type>DataCurator</contributor_type>
+            </contributor>
+        </contributors>
+        <contact_name>PDS Operator</contact_name>
+        <contact_org>PDS</contact_org>
+        <contact_email>pds-operator@jpl.nasa.gov</contact_email>
+        <contact_phone>818.393.7165</contact_phone>
+    </record>
+</records>
+
+

--- a/pds_doi_service/api/util.py
+++ b/pds_doi_service/api/util.py
@@ -1,7 +1,65 @@
+#
+#  Copyright 2020, by the California Institute of Technology.  ALL RIGHTS
+#  RESERVED. United States Government Sponsorship acknowledged. Any commercial
+#  use must be negotiated with the Office of Technology Transfer at the
+#  California Institute of Technology.
+#
+
+"""
+=======
+util.py
+=======
+
+Utility functions for the PDS DOI API service.
+This module is adapted from the SwaggerHub auto-generated util.py.
+"""
+
 import datetime
 
+from collections import Iterable
 import six
 import typing
+
+
+def format_exceptions(exceptions):
+    """
+    Formats a listing of exceptions into a JSON-friendly representation suitable
+    for return in an HTTP response.
+
+    Parameters
+    ----------
+    exceptions : Exception or list or tuple of Exception
+        The listing of exceptions to format. A single Exception instance may
+        be provided as well.
+
+    Returns
+    -------
+    formatted_exceptions : dict
+        The provided exceptions in the following format:
+
+        ```python
+        {
+            'errors': [
+                {
+                    'name': <Exception class name>,
+                    'message': <Exception message>
+                },
+                ...
+            ]
+        }
+        ```
+
+    """
+    # Check if we were given a single exception, rather than a listing
+    if not isinstance(exceptions, Iterable):
+        exceptions = [exceptions]
+
+    return {
+        'errors': [
+            {'name': type(exception).__name__, 'message': str(exception)}
+            for exception in exceptions
+        ]
+    }
 
 
 def _deserialize(data, klass):

--- a/pds_doi_service/core/actions/check.py
+++ b/pds_doi_service/core/actions/check.py
@@ -67,7 +67,7 @@ class DOICoreActionCheck(DOICoreAction):
                                                          query_dict,
                                                          i_username=self._config.get('OSTI', 'user'),
                                                          i_password=self._config.get('OSTI', 'password'))
-        dois = DOIOstiWebParser.response_get_parse_osti_xml(doi_xml)
+        dois, _ = DOIOstiWebParser.response_get_parse_osti_xml(doi_xml)
 
         if dois:
             doi = dois[0]

--- a/pds_doi_service/core/actions/release.py
+++ b/pds_doi_service/core/actions/release.py
@@ -9,7 +9,7 @@
 
 from pds_doi_service.core.actions.action import DOICoreAction, logger
 from pds_doi_service.core.input.exceptions import UnknownNodeException, InputFormatException, DuplicatedTitleDOIException, \
-    UnexpectedDOIActionException, TitleDoesNotMatchProductTypeException, SiteURNotExistException, IllegalDOIActionException, WarningDOIException, \
+    UnexpectedDOIActionException, TitleDoesNotMatchProductTypeException, SiteURLNotExistException, IllegalDOIActionException, WarningDOIException, \
     CriticalDOIException
 from pds_doi_service.core.input.osti_input_validator import OSTIInputValidator
 from pds_doi_service.core.outputs.osti import DOIOutputOsti
@@ -85,7 +85,7 @@ class DOICoreActionRelease(DOICoreAction):
     def _raise_warn_exceptions(self, exception_classes, exception_messages):
         # Raise a WarningDOIException with all the class names and messages.
 
-        message_to_raise = '' 
+        message_to_raise = ''
         for ii in range(len(exception_classes)):
             if ii == 0:
                 message_to_raise = message_to_raise +        exception_classes[ii] + ':' + exception_messages[ii]
@@ -101,11 +101,11 @@ class DOICoreActionRelease(DOICoreAction):
         :param doi_label:
         :return:
         """
-        exception_classes  = [] 
-        exception_messages = [] 
+        exception_classes  = []
+        exception_messages = []
         try:
 
-            dois = DOIOstiWebParser().response_get_parse_osti_xml(doi_label)
+            dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(doi_label)
 
             for doi in dois:
                 try:
@@ -117,7 +117,7 @@ class DOICoreActionRelease(DOICoreAction):
                     self._doi_validator.validate_osti_submission(doi)
 
                 except (DuplicatedTitleDOIException, UnexpectedDOIActionException,
-                        TitleDoesNotMatchProductTypeException, SiteURNotExistException) as e:
+                        TitleDoesNotMatchProductTypeException, SiteURLNotExistException) as e:
                     (exception_classes, exception_messages) = \
                         self._collect_exception_classes_and_messages(e,
                                                                      exception_classes,
@@ -156,7 +156,7 @@ class DOICoreActionRelease(DOICoreAction):
 
             # warnings
             except (DuplicatedTitleDOIException, UnexpectedDOIActionException,
-                    TitleDoesNotMatchProductTypeException, SiteURNotExistException, WarningDOIException) as e:
+                    TitleDoesNotMatchProductTypeException, SiteURLNotExistException, WarningDOIException) as e:
                 if not self._force:
                     # If the user did not use --force parameter, re-raise the exception.
                     raise WarningDOIException(str(e))

--- a/pds_doi_service/core/input/exceptions.py
+++ b/pds_doi_service/core/input/exceptions.py
@@ -8,6 +8,14 @@ class UnknownNodeException(Exception):
     pass
 
 
+class UnknownLIDVIDException(Exception):
+    pass
+
+
+class NoTransactionHistoryForLIDVIDException(Exception):
+    pass
+
+
 class DuplicatedTitleDOIException(Exception):
     pass
 
@@ -31,6 +39,7 @@ class CriticalDOIException(Exception):
 class WarningDOIException(Exception):
     pass
 
-class SiteURNotExistException(Exception):
+
+class SiteURLNotExistException(Exception):
     pass
 

--- a/pds_doi_service/core/outputs/osti_web_client.py
+++ b/pds_doi_service/core/outputs/osti_web_client.py
@@ -60,8 +60,9 @@ class DOIOstiWebClient:
                                  data=payload,
                                  headers=headers)
 
-        # Re-use the parse function response_get_parse_osti_xml() from DOIOstiWebParser class instead of duplicating code.
-        doi = self._web_parser.response_get_parse_osti_xml(response.text)
+        # Re-use the parse function response_get_parse_osti_xml() from
+        # DOIOstiWebParser class instead of duplicating code.
+        doi, _ = self._web_parser.response_get_parse_osti_xml(response.text)
 
         logger.debug(f"o_status {doi}")
 

--- a/pds_doi_service/core/util/doi_validator.py
+++ b/pds_doi_service/core/util/doi_validator.py
@@ -16,7 +16,7 @@ import requests
 from pds_doi_service.core.db.doi_database import DOIDataBase
 from pds_doi_service.core.entities.doi import Doi
 from pds_doi_service.core.input.exceptions import DuplicatedTitleDOIException,  \
-    IllegalDOIActionException, UnexpectedDOIActionException, TitleDoesNotMatchProductTypeException, SiteURNotExistException
+    IllegalDOIActionException, UnexpectedDOIActionException, TitleDoesNotMatchProductTypeException, SiteURLNotExistException
 from pds_doi_service.core.util.config_parser import DOIConfigUtil
 from pds_doi_service.core.util.general_util import get_logger
 
@@ -74,7 +74,7 @@ class DOIValidator:
                 error_message = f"site_url {doi.site_url} not reachable"
                 # Although not being able to connect is an error, the message printed is a warning.
                 logger.warning(error_message)
-                raise SiteURNotExistException(error_message)
+                raise SiteURLNotExistException(error_message)
 
         return 1
 

--- a/pds_doi_service/core/util/initialize_production_deployment.py
+++ b/pds_doi_service/core/util/initialize_production_deployment.py
@@ -11,7 +11,7 @@
 #
 # Parameters to this script:
 #
-#    The -s (required) is email of the PDS operator: -s pds-operator@jpl.nasa.gov 
+#    The -s (required) is email of the PDS operator: -s pds-operator@jpl.nasa.gov
 #    The -i is optional. If the input is provided and is a file, parse from it, otherwise query from the URL input: -i https://www.osti.gov/iad2/api/records
 #        The format of input XML file is the same format of text returned from querying the OSTI server via a browser or curl command.
 #        If provided and a URL of the OSTI server, this will override the url in the config file.
@@ -85,7 +85,7 @@ def _read_from_local_xml(path):
             doi_xml = f.read()
     except Exception as e:
         raise CriticalDOIException(str(e))
-    dois = DOIOstiWebParser.response_get_parse_osti_xml(doi_xml)
+    dois, _ = DOIOstiWebParser.response_get_parse_osti_xml(doi_xml)
     return dois
 
 def _read_from_path(path):
@@ -119,11 +119,11 @@ def get_dois_from_osti(target_url):
                                                          query_dict,
                                                          i_username=m_config.get('OSTI', 'user'),
                                                          i_password=m_config.get('OSTI', 'password'))
-        dois = DOIOstiWebParser.response_get_parse_osti_xml(doi_xml)
+        dois, _ = DOIOstiWebParser.response_get_parse_osti_xml(doi_xml)
 
         logger.info(f"o_server_url,len(dois) {o_server_url,len(dois)}")
 
-        return dois, o_server_url 
+        return dois, o_server_url
 
 def _get_node_id_from_contributors(doi_field):
     # Given a doi object, attempt to extract the node_id from contributors field.  If not able to, return 'eng' as default.
@@ -190,7 +190,7 @@ def perform_import_to_database(db_name, input, dry_run, submitter_email):
     # If set to True, the parameter pds_registration_doi_token in config/conf.ini should be set to 10.17189.
     use_doi_filtering_flag = False
     if use_doi_filtering_flag:
-        o_pds_doi_token = m_config.get('OTHER','pds_registration_doi_token') 
+        o_pds_doi_token = m_config.get('OTHER','pds_registration_doi_token')
 
     # If flag skip_db_write_flag set to True, will skip writing of records to database.  Use by developer to skip database write action.
     # For normal operation, skip_db_write_flag should be set to False.
@@ -203,7 +203,7 @@ def perform_import_to_database(db_name, input, dry_run, submitter_email):
     # If db_name is not provided, get one from config file:
     if db_name is None:
         # This is the local database (the metadata from OSTI) will be written to.
-        o_db_name = m_config.get('OTHER','db_file') 
+        o_db_name = m_config.get('OTHER','db_file')
         # TODO: remove next line once done testing.
         #o_db_name = 'temp_doi_temp.db'
     else:
@@ -227,10 +227,10 @@ def perform_import_to_database(db_name, input, dry_run, submitter_email):
         dois, o_server_url = get_dois_from_osti(input)
 
     o_records_found = len(dois)
-    
+
     logger.info(f"input,o_server_url,o_records_found {input,o_server_url,o_records_found}")
 
-    transaction_dir = m_config.get('OTHER','transaction_dir') 
+    transaction_dir = m_config.get('OTHER','transaction_dir')
     transaction_time = datetime.now()
 
     # Because the database requires transaction_key to be non-null, we build one here for 'eng' node for all transactions.
@@ -251,7 +251,7 @@ def perform_import_to_database(db_name, input, dry_run, submitter_email):
                 continue # Skip this record because it is not associated with the DOI group given to PDS.
 
         # If the field 'related_identifier' is None, we cannot proceed since database writing does not allow a None value.
-        lidvid = [None] 
+        lidvid = [None]
         if doi.related_identifier is None:
                 logger.debug(f"SKIPPING_NONE_RELATED_IDENTIFIER {doi.doi}")
                 o_records_dois_skipped += 1
@@ -321,7 +321,7 @@ def main():
     if arguments.submitter_email is None: # Value of arguments.submitter_email can be None if -s parameter becomes optional.
         submitter_email = 'pds-operator@jpl.nasa.gov'  # Use default value
     else:
-        submitter_email = arguments.submitter_email 
+        submitter_email = arguments.submitter_email
     dry_run = False
     # Note that the parameter --dry-run (with dash) is now dry_run (with underscore) in arguments object.
     if arguments.dry_run is not None and arguments.dry_run == True:


### PR DESCRIPTION
**Summary**
This PR adds an implementation for the release POST endpoint of the DOI Service API. The release endpoint expects an LID or LIDVID corresponding to the existing draft or reserve record to release. The LID is used to obtain the OSTI label associated with the original request (via the list action), and this is submitted to the release action and result is returned.

**Test Data and/or Report**
Unit tests have been added for the new release endpoint. Additionally, tests have been reworked to utilize `unittest.mock.patch` for stubbing out the calls to the core action classes.
[test_results.txt](https://github.com/NASA-PDS/pds-doi-service/files/5520770/test_results.txt)

**Related Issues**
#113 #106 #79 
