### PR TITLE
DOI Record Date Management

### DIFF
--- a/pds_doi_service/api/models/doi_record.py
+++ b/pds_doi_service/api/models/doi_record.py
@@ -12,7 +12,7 @@ class DoiRecord(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, doi: str = None, lidvid: str = None,
+    def __init__(self, doi: str = None, lidvid: str = None, node: str = None,
                  submitter: str = None, status: str = None,
                  creation_date: datetime = None, update_date: datetime = None,
                  record: str = None, message: str = None):  # noqa: E501
@@ -22,6 +22,8 @@ class DoiRecord(Model):
         :type doi: str
         :param lidvid: The lidvid of this DoiRecord.  # noqa: E501
         :type lidvid: str
+        :param node: The node of this DoiRecord.  # noqa: E501
+        :type node: str
         :param submitter: The submitter of this DoiRecord.  # noqa: E501
         :type submitter: str
         :param status: The status of this DoiRecord.  # noqa: E501
@@ -38,6 +40,7 @@ class DoiRecord(Model):
         self.swagger_types = {
             'doi': str,
             'lidvid': str,
+            'node': str,
             'submitter': str,
             'status': str,
             'creation_date': datetime,
@@ -49,6 +52,7 @@ class DoiRecord(Model):
         self.attribute_map = {
             'doi': 'doi',
             'lidvid': 'lidvid',
+            'node': 'node',
             'submitter': 'submitter',
             'status': 'status',
             'creation_date': 'creation_date',
@@ -58,6 +62,7 @@ class DoiRecord(Model):
         }
         self._doi = doi
         self._lidvid = lidvid
+        self._node = node
         self._submitter = submitter
         self._status = status
         self._creation_date = creation_date
@@ -117,6 +122,27 @@ class DoiRecord(Model):
         """
 
         self._lidvid = lidvid
+
+    @property
+    def node(self) -> str:
+        """Gets the node of this DoiRecord.
+
+
+        :return: The node of this DoiRecord.
+        :rtype: str
+        """
+        return self._node
+
+    @node.setter
+    def node(self, node: str):
+        """Sets the node of this DoiRecord.
+
+
+        :param node: The node of this DoiRecord.
+        :type node: str
+        """
+
+        self._node = node
 
     @property
     def submitter(self) -> str:

--- a/pds_doi_service/api/models/doi_summary.py
+++ b/pds_doi_service/api/models/doi_summary.py
@@ -12,46 +12,46 @@ class DoiSummary(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, doi: str = None, lidvid: str = None,
+    def __init__(self, doi: str = None, lidvid: str = None, node: str = None,
                  submitter: str = None, status: str = None,
-                 creation_date: datetime = None, update_date: datetime = None):  # noqa: E501
+                 update_date: datetime = None):  # noqa: E501
         """DoiSummary - a model defined in Swagger
 
         :param doi: The doi of this DoiSummary.  # noqa: E501
         :type doi: str
         :param lidvid: The lidvid of this DoiSummary.  # noqa: E501
         :type lidvid: str
+        :param node: The node of this DoiSummary.  # noqa: E501
+        :type node: str
         :param submitter: The submitter of this DoiSummary.  # noqa: E501
         :type submitter: str
         :param status: The status of this DoiSummary.  # noqa: E501
         :type status: str
-        :param creation_date: The creation_date of this DoiSummary.  # noqa: E501
-        :type creation_date: datetime
         :param update_date: The update_date of this DoiSummary.  # noqa: E501
         :type update_date: datetime
         """
         self.swagger_types = {
             'doi': str,
             'lidvid': str,
+            'node': str,
             'submitter': str,
             'status': str,
-            'creation_date': datetime,
             'update_date': datetime
         }
 
         self.attribute_map = {
             'doi': 'doi',
             'lidvid': 'lidvid',
+            'node': 'node',
             'submitter': 'submitter',
             'status': 'status',
-            'creation_date': 'creation_date',
             'update_date': 'update_date'
         }
         self._doi = doi
         self._lidvid = lidvid
+        self._node = node
         self._submitter = submitter
         self._status = status
-        self._creation_date = creation_date
         self._update_date = update_date
 
     @classmethod
@@ -108,6 +108,27 @@ class DoiSummary(Model):
         self._lidvid = lidvid
 
     @property
+    def node(self) -> str:
+        """Gets the node of this DoiSummary.
+
+
+        :return: The node of this DoiSummary.
+        :rtype: str
+        """
+        return self._node
+
+    @node.setter
+    def node(self, node: str):
+        """Sets the node of this DoiSummary.
+
+
+        :param node: The node of this DoiSummary.
+        :type node: str
+        """
+
+        self._node = node
+
+    @property
     def submitter(self) -> str:
         """Gets the submitter of this DoiSummary.
 
@@ -148,27 +169,6 @@ class DoiSummary(Model):
         """
 
         self._status = status
-
-    @property
-    def creation_date(self) -> datetime:
-        """Gets the creation_date of this DoiSummary.
-
-
-        :return: The creation_date of this DoiSummary.
-        :rtype: datetime
-        """
-        return self._creation_date
-
-    @creation_date.setter
-    def creation_date(self, creation_date: datetime):
-        """Sets the creation_date of this DoiSummary.
-
-
-        :param creation_date: The creation_date of this DoiSummary.
-        :type creation_date: datetime
-        """
-
-        self._creation_date = creation_date
 
     @property
     def update_date(self) -> datetime:

--- a/pds_doi_service/api/swagger/swagger.yaml
+++ b/pds_doi_service/api/swagger/swagger.yaml
@@ -346,20 +346,19 @@ components:
           type: string
         lidvid:
           type: string
+        node:
+          type: string
         submitter:
           type: string
         status:
           type: string
-        creation_date:
-          type: string
-          format: date-time
         update_date:
           type: string
           format: date-time
       example:
+        node: eng
         submitter: my.email@node.gov
         lidvid: urn:nasa:pds:lab_shocked_feldspars::1.0
-        creation_date: 2000-08-22T12:00:00.000+00:00
         update_date: 2001-01-23T04:56:07.000+00:00
         doi: 10.17189/21734
         status: Pending
@@ -371,5 +370,9 @@ components:
           record:
             type: string
             description: full OSTI XML label
+          creation_date:
+            type: string
+            description: Creation date of the DOI record in iso8601 format
+            format: date-time
           message:
             type: string

--- a/pds_doi_service/api/test/test_dois_controller.py
+++ b/pds_doi_service/api/test/test_dois_controller.py
@@ -90,8 +90,11 @@ class TestDoisController(BaseTestCase):
         self.assertEqual(summary.status, 'Draft')
 
         # Test filtering by start/end date
-        query_string = [('start_date', '2020-10-20T14:04:13.000000'),
-                        ('end_date', '2020-10-20T14:04:14.000000'),
+        # Note: this test was originally developed on PDT, so its important
+        #       to include the correct time zone offset as part of the query
+        #       to ensure this test works correctly in other tz's.
+        query_string = [('start_date', '2020-10-20T14:04:13.000000-07:00'),
+                        ('end_date', '2020-10-20T14:04:14.000000-07:00'),
                         ('db_name', test_db)]
 
         response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
@@ -144,7 +147,7 @@ class TestDoisController(BaseTestCase):
         # Finally, test with a malformed start/end date and ensure we
         # get "invalid argument" code back
         query_string = [('start_date', '2020-10-20 14:04:13.000000'),
-                        ('end_date', '2020-10-20T14:04'),
+                        ('end_date', '10-20-2020 14:04'),
                         ('db_name', test_db)]
 
         response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
@@ -354,7 +357,8 @@ class TestDoisController(BaseTestCase):
         """
         return json.dumps(
             [
-                {"status": "Draft", "update_date": 1603227852.560568,
+                {"status": "Draft",
+                 "update_date": '2020-10-20T14:04:12.560568-07:00',
                  "submitter": "eng-submitter@jpl.nasa.gov",
                  "title": "InSight Cameras Bundle 1.1", "type": "Dataset",
                  "subtype": "PDS4 Refereed Data Bundle", "node_id": "eng",

--- a/pds_doi_service/api/test/test_dois_controller.py
+++ b/pds_doi_service/api/test/test_dois_controller.py
@@ -92,9 +92,9 @@ class TestDoisController(BaseTestCase):
         # Test filtering by start/end date
         # Note: this test was originally developed on PDT, so its important
         #       to include the correct time zone offset as part of the query
-        #       to ensure this test works correctly in other tz's.
-        query_string = [('start_date', '2020-10-20T14:04:13.000000-07:00'),
-                        ('end_date', '2020-10-20T14:04:14.000000-07:00'),
+
+        query_string = [('start_date', '2020-10-20T21:04:13.000000+08:00'),
+                        ('end_date', '2020-10-20T21:04:14.000000+08:00'),
                         ('db_name', test_db)]
 
         response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',

--- a/pds_doi_service/api/test/test_dois_controller.py
+++ b/pds_doi_service/api/test/test_dois_controller.py
@@ -84,6 +84,7 @@ class TestDoisController(BaseTestCase):
         # Reformat JSON result into a DoiSummary object so we can check fields
         summary = DoiSummary.from_dict(records[0])
 
+        self.assertEqual(summary.node, 'eng')
         self.assertEqual(summary.submitter, 'eng-submitter@jpl.nasa.gov')
         self.assertEqual(summary.lidvid, 'urn:nasa:pds:insight_cameras::1.1')
         self.assertEqual(summary.status, 'Draft')
@@ -109,6 +110,7 @@ class TestDoisController(BaseTestCase):
         # Reformat JSON result into a DoiSummary object so we can check fields
         summary = DoiSummary.from_dict(records[0])
 
+        self.assertEqual(summary.node, 'img')
         self.assertEqual(summary.submitter, 'img-submitter@jpl.nasa.gov')
         self.assertEqual(summary.lidvid, 'urn:nasa:pds:insight_cameras::1.0')
         self.assertEqual(summary.status, 'reserved_not_submitted')
@@ -134,6 +136,7 @@ class TestDoisController(BaseTestCase):
         # Reformat JSON result into a DoiSummary object so we can check fields
         summary = DoiSummary.from_dict(records[0])
 
+        self.assertEqual(summary.node, 'img')
         self.assertEqual(summary.submitter, 'img-submitter@jpl.nasa.gov')
         self.assertEqual(summary.lidvid, 'urn:nasa:pds:lab_shocked_feldspars')
         self.assertEqual(summary.status, 'reserved_not_submitted')
@@ -193,6 +196,7 @@ class TestDoisController(BaseTestCase):
         # fields
         draft_record = DoiRecord.from_dict(draft_response.json[0])
 
+        self.assertEqual(draft_record.node, 'eng')
         self.assertEqual(draft_record.submitter, 'eng-submitter@jpl.nasa.gov')
         self.assertEqual(draft_record.lidvid, 'urn:nasa:pds:insight_cameras::1.1')
         # Note we get Pending back from the parsed label, however
@@ -229,6 +233,7 @@ class TestDoisController(BaseTestCase):
         # fields
         draft_record = DoiRecord.from_dict(draft_response.json[0])
 
+        self.assertEqual(draft_record.node, 'eng')
         self.assertEqual(draft_record.submitter, 'eng-submitter@jpl.nasa.gov')
         self.assertEqual(draft_record.lidvid, 'urn:nasa:pds:insight_cameras::1.1')
         # Note we get Pending back from the parsed label, however
@@ -283,6 +288,7 @@ class TestDoisController(BaseTestCase):
         # fields
         reserve_record = DoiRecord.from_dict(reserve_response.json[0])
 
+        self.assertEqual(reserve_record.node, 'img')
         self.assertEqual(reserve_record.submitter, 'img-submitter@jpl.nasa.gov')
         self.assertEqual(reserve_record.lidvid, 'urn:nasa:pds:lab_shocked_feldspars')
         self.assertEqual(reserve_record.status, 'reserved_not_submitted')
@@ -398,6 +404,7 @@ class TestDoisController(BaseTestCase):
         # fields
         release_record = DoiRecord.from_dict(release_response.json[0])
 
+        self.assertEqual(release_record.node, 'eng')
         self.assertEqual(release_record.submitter, 'eng-submitter@jpl.nasa.gov')
         self.assertEqual(release_record.lidvid, 'urn:nasa:pds:insight_cameras::1.1')
         self.assertEqual(release_record.status, 'Released')
@@ -565,9 +572,10 @@ class TestDoisController(BaseTestCase):
         # fields
         record = DoiRecord.from_dict(response.json)
 
+        self.assertEqual(record.node, 'eng')
         self.assertEqual(record.submitter, 'eng-submitter@jpl.nasa.gov')
         self.assertEqual(record.lidvid, 'urn:nasa:pds:insight_cameras::1.1')
-        self.assertEqual(record.status, 'Draft')
+        self.assertEqual(record.status, 'Pending')
 
         # Make sure we only got one record back
         root = etree.fromstring(bytes(record.record, encoding='utf-8'))
@@ -589,9 +597,10 @@ class TestDoisController(BaseTestCase):
 
         record = DoiRecord.from_dict(response.json)
 
+        self.assertEqual(record.node, 'eng')
         self.assertEqual(record.submitter, 'eng-submitter@jpl.nasa.gov')
         self.assertEqual(record.lidvid, 'urn:nasa:pds:insight_cameras')
-        self.assertEqual(record.status, 'Draft')
+        self.assertEqual(record.status, 'Pending')
 
         # Make sure we only got one record back
         root = etree.fromstring(bytes(record.record, encoding='utf-8'))

--- a/pds_doi_service/core/actions/list.py
+++ b/pds_doi_service/core/actions/list.py
@@ -79,10 +79,10 @@ class DOICoreActionList(DOICoreAction):
             self._query_criterias['status'] = status.lstrip().rstrip().split(',')
 
         if start_update:
-            self._query_criterias['start_update'] = datetime.strptime(start_update, '%Y-%m-%dT%H:%M:%S.%f')
+            self._query_criterias['start_update'] = datetime.fromisoformat(start_update)
 
         if end_update:
-            self._query_criterias['end_update'] = datetime.strptime(end_update, '%Y-%m-%dT%H:%M:%S.%f')
+            self._query_criterias['end_update'] = datetime.fromisoformat(end_update)
 
     @classmethod
     def add_to_subparser(cls, subparsers):
@@ -153,6 +153,12 @@ class DOICoreActionList(DOICoreAction):
             if self._format == 'JSON':
                 result_json = []
                 for row in rows:
+                    # Convert the update time from Unix epoch to iso8601 including tz
+                    row = list(row)
+                    update_date = row[columns.index('update_date')]
+                    update_date = datetime.fromtimestamp(update_date).astimezone().isoformat()
+                    row[columns.index('update_date')] = update_date
+
                     result_json.append({columns[i]: row[i]
                                         for i in range(len(columns))})
                 o_query_result = json.dumps(result_json)

--- a/pds_doi_service/core/actions/list.py
+++ b/pds_doi_service/core/actions/list.py
@@ -7,7 +7,7 @@
 #
 # ------------------------------
 
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 import json
 
 from pds_doi_service.core.actions.action import DOICoreAction, logger
@@ -156,7 +156,9 @@ class DOICoreActionList(DOICoreAction):
                     # Convert the update time from Unix epoch to iso8601 including tz
                     row = list(row)
                     update_date = row[columns.index('update_date')]
-                    update_date = datetime.fromtimestamp(update_date).astimezone().isoformat()
+                    update_date = datetime.fromtimestamp(update_date, tz=timezone.utc)\
+                        .replace(tzinfo=timezone(timedelta(hours=--8.0))) \
+                        .isoformat()
                     row[columns.index('update_date')] = update_date
 
                     result_json.append({columns[i]: row[i]

--- a/pds_doi_service/core/db/doi_database.py
+++ b/pds_doi_service/core/db/doi_database.py
@@ -281,7 +281,7 @@ class DOIDataBase:
         logger.debug(f"DEFAULT_DB_NAME {self.get_database_name()}")
 
         data_tuple = (status, product_type, product_type_specific, True, lid, vid, doi,
-                      submitter, transaction_date.timestamp(), discipline_node, title, transaction_key)
+                      submitter, transaction_date.replace(tzinfo=datetime.timezone.utc).timestamp(), discipline_node, title, transaction_key)
 
         logger.debug(f"TRANSACTION_INFO:data_tuple {data_tuple}")
 
@@ -381,11 +381,11 @@ class DOIDataBase:
 
     @staticmethod
     def _get_query_criteria_start_update(v):
-        return ' AND update_date >= :start_update', {'start_update': v.timestamp()}
+        return ' AND update_date >= :start_update', {'start_update': v.replace(tzinfo=datetime.timezone.utc).timestamp()}
 
     @staticmethod
     def _get_query_criteria_end_update(v):
-        return ' AND update_date <= :end_update', {'end_update': v.timestamp()}
+        return ' AND update_date <= :end_update', {'end_update': v.replace(tzinfo=datetime.timezone.utc).timestamp()}
 
     @staticmethod
     def parse_criteria(query_criterias):


### PR DESCRIPTION
**Summary**
This PR rolls up a number of fixes to how dates (datetime objects) are handled, both when provided to the DOI service, as well as when they are returned to a user. This includes:

* Updating the `DoiRecord` and `DoiSummary` class to include a `node` field, and moving the `creation_date` field out of `DoiSummary`
* Updating the core service `list` action to parse start/end time filters as iso8601 strings, as well as return `update_date` as an iso8601 string
* Fixing a time-zone related bug in the API unit tests

**Test Data and/or Report**
Unit tests have been updated where necessary to account for the new `node` field and iso8601 time strings.
[test_results.txt](https://github.com/NASA-PDS/pds-doi-service/files/5662495/test_results.txt)


**Related Issues**
Fixes #126, #127, and #128 
