### PR TITLE
transform relative path in config in absolute path based on sys.prefix

### DIFF
--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -65,6 +65,13 @@ You MUST set the OSTI service user and password to be able to reserve or release
 
 Ask the code to pds-operator@jpl.nasa.gov
 
+The tool uses a local database and file system space to store transactions. The default location for these files is the sys.prefix, however it can be updated as follow in the configuration::
+
+    [OTHER]
+    transaction_dir = <directory absolute path>
+    db_file = <database absolute path>/doi.db
+
+
 You can also change the log level by changing the configuration::
 
     [OTHER]

--- a/pds_doi_service/core/util/config_parser.py
+++ b/pds_doi_service/core/util/config_parser.py
@@ -18,6 +18,16 @@ logging.basicConfig(level=logging.ERROR)
 
 class DOIConfigUtil:
 
+    @staticmethod
+    def _resolve_relative_path(parser):
+        # resolve relative path with sys.prefix base path
+        for section in parser.sections():
+            for (key, val) in parser.items(section):
+                if key.endswith('_file') or key.endswith('_dir'):
+                    parser[section][key] = os.path.abspath(os.path.join(sys.prefix, val))
+
+        return parser
+
     def get_config(self):
         parser = configparser.ConfigParser()
         # default configuration
@@ -30,5 +40,6 @@ class DOIConfigUtil:
         logging.info(f"search configuration files in {candidates_full_path}")
         found = parser.read(candidates_full_path)
         logging.info(f"used configuration following files {found}")
+        parser = DOIConfigUtil._resolve_relative_path(parser)
         return parser
 

--- a/pds_doi_service/core/util/test/config_parser_test.py
+++ b/pds_doi_service/core/util/test/config_parser_test.py
@@ -1,0 +1,15 @@
+import unittest
+import sys
+import os
+from pds_doi_service.core.util.config_parser import DOIConfigUtil
+
+class ConfigParserTest(unittest.TestCase):
+    def test_add_absolute_path(self):
+
+        parser = DOIConfigUtil().get_config()
+        self.assertEqual(parser['OTHER']['db_file'], os.path.join(sys.prefix, 'doi.db'))
+        self.assertEqual(parser['OTHER']['transaction_dir'], os.path.join(sys.prefix, 'transaction_history'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Summary***
The bug was that sqllite database and transaction directory were created whereever the command line tool was lauching from.
I adding a function to transform to absolute path any property finishing with _file or _dir in the configuration. 

A new unit test has been created for that.

Attached to bug #122 