### PR TITLE
DOI API Submit Endpoint/--lidvid option for Draft Action

### DIFF
--- a/input/DOI_Release_20200727_from_review.xml
+++ b/input/DOI_Release_20200727_from_review.xml
@@ -14,14 +14,26 @@
         <date_record_added></date_record_added>
         <keywords>PDS; PDS4;</keywords>
         <authors>
-             <author>
-                <last_name>Deen</last_name>
+            <author>
                 <first_name>R.</first_name>
+                <last_name>Deen</last_name>
+            </author>
+             <author>
+                <first_name>H.</first_name>
+                <last_name>Abarca</last_name>
+            </author>
+             <author>
+                <first_name>P.</first_name>
+                <last_name>Zamani</last_name>
+            </author>
+             <author>
+                <first_name>J.</first_name>
+                <last_name>Maki</last_name>
             </author>
         </authors>
         <contributors>
             <contributor>
-                <full_name>Planetary Data System:  Node</full_name>
+                <full_name>Planetary Data System: Engineering Node</full_name>
                 <contributor_type>DataCurator</contributor_type>
             </contributor>
         </contributors>

--- a/pds_doi_service/api/swagger/swagger.yaml
+++ b/pds_doi_service/api/swagger/swagger.yaml
@@ -272,34 +272,33 @@ paths:
           type: string
       responses:
         "501":
-          description: Not Implemented
+          description: Not implemented
       x-openapi-router-controller: pds_doi_service.api.controllers.dois_controller
-  /dois/{lidvid}/release:
+  /dois/{lidvid}/submit:
     post:
       tags:
       - dois
-      description: Move a DOI record from draft/reserve status to "release".
-      operationId: post_release_doi
+      description: Move a DOI record from draft/reserve status to "review".
+      operationId: post_submit_doi
       parameters:
       - name: lidvid
         in: path
-        description: The LIDVID associated with the record to release.
+        description: The LIDVID associated with the record to submit for review.
         required: true
         style: simple
         explode: false
         schema:
           type: string
-        example: 'urn:nasa:pds:lab_shocked_feldspars::1.0'
+        example: urn:nasa:pds:lab_shocked_feldspars::1.0
       - name: force
         in: query
-        description: If true, forces a release request to completion, ignoring any
+        description: If true, forces a submit request to completion, ignoring any
           warnings encountered.
         required: false
         style: form
         explode: true
         schema:
           type: boolean
-          default: false
       responses:
         "200":
           description: Success

--- a/pds_doi_service/api/swagger/swagger.yaml
+++ b/pds_doi_service/api/swagger/swagger.yaml
@@ -310,10 +310,53 @@ paths:
         "400":
           description: Can not be released
         "404":
-          description: Not existing
+          description: No entry found for LIDVID
         "500":
           description: Internal error
       x-openapi-router-controller: pds_doi_service.api.controllers.dois_controller
+# TODO: This routing endpoint has been commented out to effectively block access
+#       to the API's release endpoint until an authentication scheme can
+#       be incorporated to ensure only the Engineering node has access.
+#  /dois/{lidvid}/release:
+#    post:
+#      tags:
+#      - dois
+#      description: Move a DOI record from draft/reserve/review status to "release".
+#      operationId: post_release_doi
+#      parameters:
+#      - name: lidvid
+#        in: path
+#        description: The LIDVID associated with the record to release.
+#        required: true
+#        style: simple
+#        explode: false
+#        schema:
+#          type: string
+#        example: 'urn:nasa:pds:lab_shocked_feldspars::1.0'
+#      - name: force
+#        in: query
+#        description: If true, forces a release request to completion, ignoring any
+#          warnings encountered.
+#        required: false
+#        style: form
+#        explode: true
+#        schema:
+#          type: boolean
+#          default: false
+#      responses:
+#        "200":
+#          description: Success
+#          content:
+#            application/json:
+#              schema:
+#                $ref: '#/components/schemas/doi_record'
+#        "400":
+#          description: Can not be released
+#        "404":
+#          description: No entry found for LIDVID
+#        "500":
+#          description: Internal error
+#      x-openapi-router-controller: pds_doi_service.api.controllers.dois_controller
 components:
   schemas:
     label_payload:

--- a/pds_doi_service/api/test/test_dois_controller.py
+++ b/pds_doi_service/api/test/test_dois_controller.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import json
 import os
 from os.path import abspath, dirname, exists, join
+import unittest
 from unittest.mock import patch
 
 from lxml import etree
@@ -382,6 +383,30 @@ class TestDoisController(BaseTestCase):
         with open(draft_record_file, 'r') as infile:
             return infile.read()
 
+    def test_disabled_release_endpoint(self):
+        """
+        Test to ensure that the dois/{lidvid}/release is not reachable.
+
+        Note that this test should be removed if the dois/{lidvid}/release
+        endpoint is ever re-enabled, along with the @unittest.skip decorators
+        for the corresponding unit tests.
+        """
+        query_string = [('force', False),
+                        ('db_name', self.temp_db)]
+
+        release_response = self.client.open(
+            '/PDS_APIs/pds_doi_api/0.1/dois/{lidvid}/release'
+                .format(lidvid='urn:nasa:pds:insight_cameras::1.1'),
+            method='POST',
+            query_string=query_string
+        )
+
+        self.assert404(
+            release_response,
+            'Response body is : ' + release_response.data.decode('utf-8')
+        )
+
+    @unittest.skip('dois/{lidvid}/release endpoint is disabled')
     @patch.object(
         pds_doi_service.api.controllers.dois_controller.DOICoreActionRelease,
         'run', release_action_run_patch)
@@ -412,7 +437,7 @@ class TestDoisController(BaseTestCase):
         self.assertEqual(release_record.node, 'eng')
         self.assertEqual(release_record.submitter, 'eng-submitter@jpl.nasa.gov')
         self.assertEqual(release_record.lidvid, 'urn:nasa:pds:insight_cameras::1.1')
-        self.assertEqual(release_record.status, DoiStatus.Review)
+        self.assertEqual(release_record.status, DoiStatus.Pending)
         self.assertEqual(release_record.doi, '10.17189/21734')
 
         # Record field should match what we provided via patch method
@@ -430,6 +455,7 @@ class TestDoisController(BaseTestCase):
         with open(draft_record_file, 'r') as infile:
             return infile.read()
 
+    @unittest.skip('dois/{lidvid}/release endpoint is disabled')
     @patch.object(
         pds_doi_service.api.controllers.dois_controller.DOICoreActionRelease,
         'run', release_action_run_w_error_patch)
@@ -476,6 +502,7 @@ class TestDoisController(BaseTestCase):
         """
         return '[]'
 
+    @unittest.skip('dois/{lidvid}/release endpoint is disabled')
     @patch.object(
         pds_doi_service.api.controllers.dois_controller.DOICoreActionList,
         'run', list_action_run_patch_missing)
@@ -523,6 +550,7 @@ class TestDoisController(BaseTestCase):
             ]
         )
 
+    @unittest.skip('dois/{lidvid}/release endpoint is disabled')
     @patch.object(
         pds_doi_service.api.controllers.dois_controller.DOICoreActionList,
         'run', list_action_run_patch_no_transaction_history)

--- a/pds_doi_service/core/actions/draft.py
+++ b/pds_doi_service/core/actions/draft.py
@@ -17,12 +17,15 @@ import copy
 import os
 import requests
 from lxml import etree
+from os.path import exists, join
 
 from pds_doi_service.core.actions.action import DOICoreAction
+from pds_doi_service.core.actions.list import DOICoreActionList
 from pds_doi_service.core.entities.doi import DoiStatus
 from pds_doi_service.core.input.exceptions import (UnknownNodeException,
                                                    DuplicatedTitleDOIException,
                                                    UnexpectedDOIActionException,
+                                                   NoTransactionHistoryForLIDVIDException,
                                                    TitleDoesNotMatchProductTypeException,
                                                    InputFormatException,
                                                    WarningDOIException,
@@ -31,25 +34,28 @@ from pds_doi_service.core.input.node_util import NodeUtil
 from pds_doi_service.core.input.osti_input_validator import OSTIInputValidator
 from pds_doi_service.core.input.pds4_util import DOIPDS4LabelUtil
 from pds_doi_service.core.outputs.osti import DOIOutputOsti
+from pds_doi_service.core.outputs.osti_web_parser import DOIOstiWebParser
 from pds_doi_service.core.util.doi_validator import DOIValidator
 from pds_doi_service.core.util.general_util import get_logger
 
-logger = get_logger('pds_doi_core.actions.draft')
+logger = get_logger('pds_doi_service.core.actions.draft')
 
 
 class DOICoreActionDraft(DOICoreAction):
     _name = 'draft'
     _description = 'Prepare an OSTI record from PDS4 labels'
     _order = 10
-    _run_arguments = ('input', 'node', 'submitter', 'force', 'keyword')
+    _run_arguments = ('input', 'node', 'submitter', 'lidvid', 'force', 'keyword')
 
     def __init__(self, db_name=None):
         super().__init__(db_name=db_name)
         self._doi_validator = DOIValidator(db_name=db_name)
+        self._list_obj = DOICoreActionList(db_name=db_name)
 
         self._input = None
         self._node = None
         self._submitter = None
+        self._lidvid = None
         self._force = False
         self._target = None
         self._keyword = None
@@ -63,9 +69,27 @@ class DOICoreActionDraft(DOICoreAction):
 
         node_values = NodeUtil.get_permissible_values()
         action_parser.add_argument(
+            '-i', '--input', required=False,
+            metavar='input/bundle_in_with_contributors.xml',
+            help='An input PDS4 label. May be a local path or an HTTP address '
+                 'resolving to a label file. Multiple inputs may be provided '
+                 'via comma-delimited list. Must be provided if --lidvid is not '
+                 'specified.'
+        )
+        action_parser.add_argument(
             '-n', '--node', required=True,  metavar='"img"',
             help='The PDS Discipline Node in charge of the DOI. Authorized '
                  'values are: ' + ','.join(node_values)
+        )
+        action_parser.add_argument(
+            '-s', '--submitter', required=True, metavar='"my.email@node.gov"',
+            help='The email address to associate with the Draft record.'
+        )
+        action_parser.add_argument(
+            '-l', '--lidvid', required=False,
+            metavar='urn:nasa:pds:lab_shocked_feldspars::1.0',
+            help='A LIDVID for an existing DOI record to move back to draft '
+                 'status. Must be provided if --input is not specified.'
         )
         action_parser.add_argument(
             '-f', '--force', required=False, action='store_true',
@@ -75,26 +99,147 @@ class DOICoreActionDraft(DOICoreAction):
                  'treated as fatal exceptions.',
         )
         action_parser.add_argument(
-            '-i', '--input', required=True,
-            metavar='input/bundle_in_with_contributors.xml',
-            help='An input PDS4 label. May be a local path or an HTTP address '
-                 'resolving to a label file. Multiple inputs may be provided '
-                 'via comma-delimited list.'
-        )
-        action_parser.add_argument(
             '-k', '--keyword', required=False, metavar='"Image"',
             help='Extra keywords to associate with the Draft record. Multiple '
-                 'keywords must be separated by ",".'
-        )
-        action_parser.add_argument(
-            '-s', '--submitter', required=True, metavar='"my.email@node.gov"',
-            help='The email address to associate with the Draft record.'
+                 'keywords must be separated by ",". Ignored when used with the '
+                 '--lidvid option.'
         )
         action_parser.add_argument(
             '-t', '--target',  required=False, default='osti', metavar='osti',
             help='The system target to mint the DOI. Currently, only the value '
                  '"osti" is supported.'
         )
+
+    def _set_lidvid_to_draft(self, lidvid):
+        """
+        Sets the status of the transaction record corresponding to the provided
+        LIDVID back draft. This can be typical for records that do not advance
+        past the review step.
+
+        Parameters
+        ----------
+        lidvid : str
+            The LIDVID associated to the record to set to draft.
+
+        Returns
+        -------
+        doi_label : str
+            The OSTI XML label for the provided LIDVID reflecting its draft
+            (pending) status.
+
+        Raises
+        ------
+        NoTransactionHistoryForLIDVIDException
+            If an entry for the provided LIDVID exists in the transaction
+            database, but no local transaction history can be found.
+
+        """
+        # Get the output OSTI label produced from the last transaction
+        # with this LIDVID
+        transaction_record = self._list_obj.transaction_for_lidvid(lidvid)
+
+        # Make sure we can locate the output OSTI label associated with this
+        # transaction
+        transaction_location = transaction_record['transaction_key']
+        osti_label_file = join(transaction_location, 'output.xml')
+
+        if not exists(osti_label_file):
+            raise NoTransactionHistoryForLIDVIDException(
+                f'Could not find an OSTI Label associated with LIDVID {lidvid}. '
+                'The database and transaction history location may be out of sync. '
+                'Please try resubmitting the record in reserve or draft.'
+            )
+
+        # Label could contain entries for multiple LIDVIDs, so extract
+        # just the one we care about
+        lidvid_record = DOIOstiWebParser.get_record_for_lidvid(
+            osti_label_file, lidvid
+        )
+
+        # Format label into an in-memory DOI object
+        dois, errors = DOIOstiWebParser.response_get_parse_osti_xml(
+            bytes(lidvid_record, encoding='utf-8')
+        )
+
+        doi = dois[0]
+
+        # Update the status back to draft while noting the previous status
+        doi.previous_status = doi.status
+        doi.status = DoiStatus.Draft
+
+        # Update the output label to reflect new draft status
+        doi_label = DOIOutputOsti().create_osti_doi_draft_record(doi)
+
+        # Re-commit transaction to official roll DOI back to draft status
+        transaction = self.m_transaction_builder.prepare_transaction(
+            self._node, self._submitter, [doi], input_path=osti_label_file,
+            output_content=doi_label
+        )
+
+        # Commit the transaction to the database
+        transaction.log()
+
+        return doi_label
+
+    def _draft_input_files(self, inputs):
+        """
+        Creates draft records for the list of input files/locations.
+
+        Parameters
+        ----------
+        inputs : str
+            Comma-delimited listing of the inputs to produce draft records for.
+            These may be local paths to a file or directory, or remote URLs.
+
+        Returns
+        -------
+        doi_label : str
+            A OSTI XML label containing the draft records for requested inputs.
+
+        Raises
+        ------
+        CriticalDOIException
+            If any errors occur during creation of the draft records.
+
+        """
+        try:
+            contributor_value = NodeUtil().get_node_long_name(self._node)
+
+            # The value of input can be a list of names, or a directory.
+            # Resolve that to a list of names.
+            list_of_names = self._resolve_input_into_list_of_names(inputs)
+
+            # OSTI uses 'records' as the root tag.
+            o_doi_labels = etree.Element("records")
+
+            # For each name found, transform the PDS4 label to an OSTI record,
+            # then concatenate that record to o_doi_label to return.
+            for input_file in list_of_names:
+                doi_label = self._run_single_file(
+                    input_file, self._node, self._submitter, contributor_value,
+                    self._force, self._keyword
+                )
+
+                # It is possible that the value of doi_label is None if the file
+                # is not a valid label.
+                if not doi_label:
+                    continue
+
+                # Concatenate each label to o_doi_labels to return.
+                doc = etree.fromstring(doi_label.encode())
+
+                for element in doc.iter():
+                    # OSTI uses 'record' tag for each record.
+                    if element.tag == 'record':
+                        # Add the 'record' element
+                        o_doi_labels.append(copy.copy(element))
+
+            # Make the output nice by indenting it.
+            etree.indent(o_doi_labels)
+
+            return etree.tostring(o_doi_labels, pretty_print=True).decode()
+        except UnknownNodeException as err:
+            raise CriticalDOIException(str(err))
 
     def _resolve_input_into_list_of_names(self, input_labels):
         """
@@ -253,47 +398,28 @@ class DOICoreActionDraft(DOICoreAction):
         Receives a number of input label locations from which to create a
         draft Data Object Identifier (DOI). Each location may be a local directory
         or file path, or a remote HTTP address to the input XML PDS4 label file.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Contains the arguments for the Draft action as parsed from the
+            command-line.
+
+        Raises
+        ------
+        ValueError
+            If the provided arguments are invalid.
+
         """
         self.parse_arguments(kwargs)
 
-        try:
-            contributor_value = NodeUtil().get_node_long_name(self._node)
+        # Make sure we've been given something to work with
+        if self._input is None and self._lidvid is None:
+            raise ValueError('A value must be provided for either --input or '
+                             '--lidvid when using the Draft action.')
 
-            # The value of input can be a list of names, or a directory.
-            # Resolve that to a list of names.
-            list_of_names = self._resolve_input_into_list_of_names(self._input)
+        if self._lidvid:
+            return self._set_lidvid_to_draft(self._lidvid)
 
-            # OSTI uses 'records' as the root tag.
-            o_doi_labels = etree.Element("records")
-
-            # For each name found, transform the PDS4 label to an OSTI record,
-            # then concatenate that record to o_doi_label to return.
-            for input_file in list_of_names:
-                doi_label = self._run_single_file(
-                    input_file, self._node, self._submitter, contributor_value,
-                    self._force, self._keyword
-                )
-
-                # It is possible that the value of doi_label is None if the file
-                # is not a valid label.
-                if not doi_label:
-                    continue
-
-                # Concatenate each label to o_doi_labels to return.
-                doc = etree.fromstring(doi_label.encode())
-
-                for element in doc.iter():
-                    # OSTI uses 'record' tag for each record.
-                    if element.tag == 'record':
-                        # Add the 'record' element
-                        o_doi_labels.append(copy.copy(element))
-
-            # Make the output nice by indenting it.
-            etree.indent(o_doi_labels)
-
-            return etree.tostring(o_doi_labels, pretty_print=True).decode()
-        except UnknownNodeException as err:
-            raise CriticalDOIException(str(err))
-        # Re-raise any other exceptions.
-        except Exception as err:
-            raise err
+        if self._input:
+            return self._draft_input_files(self._input)

--- a/pds_doi_service/core/actions/release.py
+++ b/pds_doi_service/core/actions/release.py
@@ -139,6 +139,9 @@ class DOICoreActionRelease(DOICoreAction):
                 # Add 'status' field so the ranking in the workflow can be determined.
                 doi.status = DoiStatus.Pending if self._no_review else DoiStatus.Review
 
+                # Make sure correct contributor field is set
+                doi.contributor = NodeUtil().get_node_long_name(self._node)
+
                 single_doi_label = DOIOutputOsti().create_osti_doi_release_record(doi)
 
                 if self._config.get('OTHER', 'release_validate_against_xsd_flag').lower() == 'true':

--- a/pds_doi_service/core/actions/test/draft_test.py
+++ b/pds_doi_service/core/actions/test/draft_test.py
@@ -1,105 +1,239 @@
-import unittest
+#!/usr/bin/env python
+
 import os
+from os.path import abspath, dirname, join
+import unittest
 
 from pds_doi_service.core.actions.draft import DOICoreActionDraft
+from pds_doi_service.core.entities.doi import DoiStatus
+from pds_doi_service.core.outputs.osti_web_parser import DOIOstiWebParser
 
 
-from pds_doi_service.core.util.general_util import get_logger
-
-logger = get_logger(__name__)
-
-def create_temporary_output_file(doi_label,filename):
-    # Save doi_label so it can be compared to.
-    temporary_file_name = filename
-    temporary_file_ptr = open(temporary_file_name,"w+")
-    temporary_file_ptr.write(doi_label + "\n")
-    temporary_file_ptr.close()
-    return temporary_file_name
-
-class MyTestCase(unittest.TestCase):
-    db_name = 'doi_temp.db'
-    # Because validation has been added to each action, the force=True is required as the command line is not parsed for unit test.
+class DraftActionTestCase(unittest.TestCase):
+    # Because validation has been added to each action, the force=True is
+    # required for each test as the command line is not parsed.
 
     @classmethod
-    def setUp(self):
-        # This setUp() function is called for every test.
-        self._action = DOICoreActionDraft(db_name=self.db_name)
-        logger.info(f"Instantiate DOICoreActionDraft with database file {self.db_name}")
-        # Create output directory if one does not already exist.
-        self._temporary_output_dir = './tests/data'
-        os.makedirs(self._temporary_output_dir, exist_ok=True)
+    def setUpClass(cls):
+        cls.test_dir = abspath(dirname(__file__))
+        cls.input_dir = abspath(
+            join(cls.test_dir, os.pardir, os.pardir, os.pardir, os.pardir, 'input')
+        )
+        cls.db_name = 'doi_temp.db'
+        cls._action = DOICoreActionDraft(db_name=cls.db_name)
 
     @classmethod
-    def tearDown(self):
-        # This tearDown() function is called at end of every test.
-        if os.path.isfile(self.db_name):
-            os.remove(self.db_name)
-            logger.info(f"Removed test artifact database file {self.db_name}")
-        else:
-            logger.info(f"File not exist, test artifact database file {self.db_name}")
-
+    def tearDownClass(cls):
+        if os.path.isfile(cls.db_name):
+            os.remove(cls.db_name)
 
     def test_local_dir_one_file(self):
-        logger.info("test local dir with one file")
-        osti_doi = self._action.run(input='input/draft_dir_one_file',
-                              node='img',
-                              submitter='my_user@my_node.gov',force=True)
-        logger.info(osti_doi)
+        """Test draft request with local dir containing one file"""
+        kwargs = {
+            'input': join(self.input_dir, 'draft_dir_one_file'),
+            'node': 'img',
+            'submitter': 'my_user@my_node.gov',
+            'force': True
+        }
+
+        osti_doi = self._action.run(**kwargs)
+
+        dois, errors = DOIOstiWebParser.response_get_parse_osti_xml(osti_doi)
+
+        self.assertEqual(len(dois), 1)
+        self.assertEqual(len(errors), 0)
+
+        doi = dois[0]
+
+        self.assertEqual(len(doi.authors), 4)
+        self.assertEqual(len(doi.contributors), 1)
+        self.assertEqual(len(doi.keywords), 18)
+        self.assertEqual(doi.related_identifier,
+                         'urn:nasa:pds:insight_cameras::1.0')
+        self.assertEqual(doi.status, DoiStatus.Pending)
 
     def test_local_dir_two_files(self):
-        logger.info("test local dir with two files")
-        osti_doi = self._action.run(input='input/draft_dir_two_files',
-                              node='img',
-                              submitter='my_user@my_node.gov',force=True)
-        logger.info(osti_doi)
+        """Test draft request with local dir containing two files"""
+        kwargs = {
+            'input': join(self.input_dir, 'draft_dir_two_files'),
+            'node': 'img',
+            'submitter': 'my_user@my_node.gov',
+            'force': True
+        }
+
+        osti_doi = self._action.run(**kwargs)
+
+        dois, errors = DOIOstiWebParser.response_get_parse_osti_xml(osti_doi)
+
+        self.assertEqual(len(dois), 2)
+        self.assertEqual(len(errors), 0)
+
+        for doi in dois:
+            self.assertEqual(len(doi.authors), 4)
+            self.assertEqual(len(doi.contributors), 1)
+            self.assertEqual(len(doi.keywords), 18)
+            self.assertEqual(doi.status, DoiStatus.Pending)
+
+        self.assertEqual(dois[0].related_identifier,
+                         'urn:nasa:pds:insight_cameras::1.1')
+        self.assertEqual(dois[1].related_identifier,
+                         'urn:nasa:pds:insight_cameras::1.0')
 
     def test_local_bundle(self):
-        logger.info("test local bundle")
-        osti_doi = self._action.run(input='input/bundle_in_with_contributors.xml',
-                              node='img',
-                              submitter='my_user@my_node.gov',force=True)
-        logger.info(osti_doi)
+        """Test draft request with a local bundle path"""
+        kwargs = {
+            'input': join(self.input_dir, 'bundle_in_with_contributors.xml'),
+            'node': 'img',
+            'submitter': 'my_user@my_node.gov',
+            'force': True
+        }
+
+        osti_doi = self._action.run(**kwargs)
+
+        dois, errors = DOIOstiWebParser.response_get_parse_osti_xml(osti_doi)
+
+        self.assertEqual(len(dois), 1)
+        self.assertEqual(len(errors), 0)
+
+        doi = dois[0]
+
+        self.assertEqual(len(doi.authors), 4)
+        self.assertEqual(len(doi.contributors), 1)
+        self.assertEqual(len(doi.keywords), 18)
+        self.assertEqual(doi.related_identifier,
+                         'urn:nasa:pds:insight_cameras::1.0')
+        self.assertEqual(doi.status, DoiStatus.Pending)
 
     def test_remote_bundle(self):
-        logger.info("test remote bundle")
-        osti_doi = self._action.run(
-                                    input='https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/bundle.xml',
-                                    node='img',
-                                    submitter='my_user@my_node.gov',force=True)
-        logger.info(osti_doi)
-        #create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_bundle_doi.xml'))
+        """Test draft request with a remote bundle URL"""
+        kwargs = {
+            'input': 'https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/bundle.xml',
+            'node': 'img',
+            'submitter': 'my_user@my_node.gov',
+            'force': True
+        }
+
+        osti_doi = self._action.run(**kwargs)
+
+        dois, errors = DOIOstiWebParser.response_get_parse_osti_xml(osti_doi)
+
+        self.assertEqual(len(dois), 1)
+        self.assertEqual(len(errors), 0)
+
+        doi = dois[0]
+
+        self.assertEqual(len(doi.authors), 4)
+        self.assertEqual(len(doi.contributors), 1)
+        self.assertEqual(len(doi.keywords), 18)
+        self.assertEqual(doi.related_identifier,
+                         'urn:nasa:pds:insight_cameras::1.0')
+        self.assertEqual(doi.status, DoiStatus.Pending)
 
     def test_remote_collection(self):
-        logger.info("test remote collection")
-        osti_doi = self._action.run(
-                                    input='https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/data/collection_data.xml',
-                                    node='img', submitter='my_user@my_node.gov',force=True)
-        logger.info(osti_doi)
-        #create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_datacoll_doi.xml'))
+        """Test draft request with a remote collection URL"""
+        kwargs = {
+            'input': 'https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/data/collection_data.xml',
+            'node': 'img',
+            'submitter': 'my_user@my_node.gov',
+            'force': True
+        }
+
+        osti_doi = self._action.run(**kwargs)
+
+        dois, errors = DOIOstiWebParser.response_get_parse_osti_xml(osti_doi)
+
+        self.assertEqual(len(dois), 1)
+        self.assertEqual(len(errors), 0)
+
+        doi = dois[0]
+
+        self.assertEqual(len(doi.authors), 4)
+        self.assertEqual(len(doi.contributors), 1)
+        self.assertEqual(len(doi.keywords), 12)
+        self.assertEqual(doi.related_identifier,
+                         'urn:nasa:pds:insight_cameras:data::1.0')
+        self.assertEqual(doi.status, DoiStatus.Pending)
 
     def test_remote_browse_collection(self):
-        logger.info("test remote browse collection")
-        osti_doi = self._action.run(
-                                    input='https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/browse/collection_browse.xml',
-                                    node='img', submitter='my_user@my_node.gov',force=True)
-        logger.info(osti_doi)
-        #create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_browsecoll_doi.xml'))
+        """Test draft request with a remote browse collection URL"""
+        kwargs = {
+            'input': 'https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/browse/collection_browse.xml',
+            'node': 'img',
+            'submitter': 'my_user@my_node.gov',
+            'force': True
+        }
+
+        osti_doi = self._action.run(**kwargs)
+
+        dois, errors = DOIOstiWebParser.response_get_parse_osti_xml(osti_doi)
+
+        self.assertEqual(len(dois), 1)
+        self.assertEqual(len(errors), 0)
+
+        doi = dois[0]
+
+        self.assertEqual(len(doi.authors), 4)
+        self.assertEqual(len(doi.contributors), 1)
+        self.assertEqual(len(doi.keywords), 12)
+        self.assertEqual(doi.related_identifier,
+                         'urn:nasa:pds:insight_cameras:browse::1.0')
+        self.assertEqual(doi.description,
+                         'Collection of BROWSE products.')
+        self.assertEqual(doi.status, DoiStatus.Pending)
 
     def test_remote_calibration_collection(self):
-        logger.info("test remote calibration collection")
-        osti_doi = self._action.run(
-                                    input='https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/calibration/collection_calibration.xml',
-                                    node='img', submitter='my_user@my_node.gov',force=True)
-        logger.info(osti_doi)
-        #create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_calibcoll_doi.xml'))
+        """Test draft request with remote calibration collection URL"""
+        kwargs = {
+            'input': 'https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/calibration/collection_calibration.xml',
+            'node': 'img',
+            'submitter': 'my_user@my_node.gov',
+            'force': True
+        }
+
+        osti_doi = self._action.run(**kwargs)
+
+        dois, errors = DOIOstiWebParser.response_get_parse_osti_xml(osti_doi)
+
+        self.assertEqual(len(dois), 1)
+        self.assertEqual(len(errors), 0)
+
+        doi = dois[0]
+
+        self.assertEqual(len(doi.authors), 4)
+        self.assertEqual(len(doi.contributors), 1)
+        self.assertEqual(len(doi.keywords), 14)
+        self.assertEqual(doi.related_identifier,
+                         'urn:nasa:pds:insight_cameras:calibration::1.0')
+        self.assertEqual(doi.description,
+                         'Collection of CALIBRATION files/products to include in the archive.')
+        self.assertEqual(doi.status, DoiStatus.Pending)
 
     def test_remote_document_collection(self):
-        logger.info("test remote document collection")
-        osti_doi = self._action.run(
-                                    input='https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/document/collection_document.xml',
-                                    node='img', submitter='my_user@my_node.gov',force=True)
-        logger.info(osti_doi)
-        #create_temporary_output_file(osti_doi, os.path.join(self._temporary_output_dir,'valid_docucoll_doi.xml'))
+        """Test draft request with remote document collection URL"""
+        kwargs = {
+            'input': 'https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/document/collection_document.xml',
+            'node': 'img',
+            'submitter': 'my_user@my_node.gov',
+            'force': True
+        }
+
+        osti_doi = self._action.run(**kwargs)
+
+        dois, errors = DOIOstiWebParser.response_get_parse_osti_xml(osti_doi)
+
+        self.assertEqual(len(dois), 1)
+        self.assertEqual(len(errors), 0)
+
+        doi = dois[0]
+
+        self.assertEqual(len(doi.authors), 4)
+        self.assertEqual(len(doi.contributors), 1)
+        self.assertEqual(len(doi.keywords), 12)
+        self.assertEqual(doi.related_identifier,
+                         'urn:nasa:pds:insight_cameras:document::1.0')
+        self.assertEqual(doi.description,
+                         'Collection of DOCUMENT products.')
+        self.assertEqual(doi.status, DoiStatus.Pending)
 
 
 if __name__ == '__main__':

--- a/pds_doi_service/core/actions/test/release_test.py
+++ b/pds_doi_service/core/actions/test/release_test.py
@@ -10,12 +10,9 @@ from pds_doi_service.core.actions.release import DOICoreActionRelease
 from pds_doi_service.core.entities.doi import DoiStatus
 from pds_doi_service.core.outputs.osti import DOIOutputOsti
 from pds_doi_service.core.outputs.osti_web_parser import DOIOstiWebParser
-from pds_doi_service.core.util.general_util import get_logger
-
-logger = get_logger(__name__)
 
 
-class MyTestCase(unittest.TestCase):
+class ReleaseActionTestCase(unittest.TestCase):
     # As of 07/13/2020, OSTI has the below ID records (['22831','22832','22833'])
     # in their test server so this test will work to demonstrate that they have
     # new status of 'Pending' or 'Registered'. If for some reason the server has
@@ -34,18 +31,15 @@ class MyTestCase(unittest.TestCase):
         # raised about using existing lidvid.
         if os.path.isfile(cls.db_name):
             os.remove(cls.db_name)
-            logger.info(f"Removed test artifact database file {cls.db_name}")
 
         # Because validation has been added to each action, the force=True is
         # required as the command line is not parsed for unit test.
         cls._action = DOICoreActionRelease(db_name=cls.db_name)
-        logger.info(f"Instantiated DOICoreActionRelease with database file {cls.db_name}")
 
     @classmethod
     def tearDownClass(cls):
         if os.path.isfile(cls.db_name):
             os.remove(cls.db_name)
-            logger.info(f"Removed test artifact database file {cls.db_name}")
 
     def webclient_submit_patch(self, payload, i_url=None,
                                i_username=None, i_password=None):

--- a/pds_doi_service/core/cmd/pds_doi_cmd.py
+++ b/pds_doi_service/core/cmd/pds_doi_cmd.py
@@ -1,28 +1,35 @@
-#!/bin/python
+#!/usr/bin/env python
 #
 #  Copyright 2020, by the California Institute of Technology.  ALL RIGHTS
 #  RESERVED. United States Government Sponsorship acknowledged. Any commercial
 #  use must be negotiated with the Office of Technology Transfer at the
 #  California Institute of Technology.
 #
-# ------------------------------
+
+"""
+==============
+pds_doi_cmd.py
+==============
+
+Contains the main function for the pds_doi_cmd.py script.
+"""
+
 import importlib
 import os
-
 
 from pds_doi_service.core.util.general_util import get_logger
 from pds_doi_service.core.actions.action import DOICoreAction
 
 # Get the common logger and set the level for this file.
-logger = get_logger('pds_doi_core.cmd.pds_doi_cmd')
+logger = get_logger('pds_doi_service.core.cmd.pds_doi_cmd')
 
 
 def main():
     parser = DOICoreAction.create_cmd_parser()
     arguments = parser.parse_args()
     action_type = arguments.subcommand
+
     # Moved many argument parsing to each action class.
-    
     logger.info(f"run_dir {os.getcwd()}")
 
     module = importlib.import_module(f'pds_doi_service.core.actions.{action_type}')

--- a/pds_doi_service/core/outputs/DOI_IAD2_reserved_template_20200205-mustache.xml
+++ b/pds_doi_service/core/outputs/DOI_IAD2_reserved_template_20200205-mustache.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <records>
     {{#dois}}
-    <record status="{{status}}"> 
+    <record status="{{status}}">
         {{#id}}
         <id>{{id}}</id>
         {{/id}}
@@ -9,14 +9,16 @@
         <id></id>
         {{/id}}
         <title>{{title}}</title>
+        {{#doi}}
+        <doi>{{doi}}</doi>
+        {{/doi}}
         <sponsoring_organization>National Aeronautics and Space Administration (NASA)</sponsoring_organization>
         <accession_number>{{related_identifier}}</accession_number>
         <publisher>{{publisher}}</publisher>
-          {{#doi}}
-        <doi>{{doi}}</doi>
-        {{/doi}}
-        <availability></availability>
+        <availability>NASA Planetary Data System</availability>
         <publication_date>{{publication_date}}</publication_date>
+        <country>USA</country>
+        <description>{{description}}</description>
         {{#site_url}}
         <site_url>{{site_url}}</site_url>
         {{/site_url}}
@@ -26,7 +28,7 @@
         <product_type>{{product_type}}</product_type>
         <product_type_specific>{{product_type_specific}}</product_type_specific>
         <date_record_added>{{date_record_added}}</date_record_added>
-        <keywords>PDS; PDS4;</keywords>
+        <keywords>{{keywords}}</keywords>
         <authors>
             {{#authors}}
              <author>
@@ -61,7 +63,7 @@
                 {{#full_name}}
                 <full_name>{{full_name}}</full_name>
                 {{/full_name}}
-                <contributor_type>DataCurator</contributor_type>
+                <contributor_type>Editor</contributor_type>
                 <affiliations/>
             </contributor>
             {{/editors}}
@@ -77,5 +79,3 @@
     </record>
     {{/dois}}
 </records>
-
-

--- a/pds_doi_service/core/outputs/DOI_template_20200407-mustache.xml
+++ b/pds_doi_service/core/outputs/DOI_template_20200407-mustache.xml
@@ -17,8 +17,7 @@
         <availability>NASA Planetary Data System</availability>
         <publication_date>{{publication_date}}</publication_date>
         <country>USA</country>
-        <description>{{description}}
-        </description>
+        <description>{{description}}</description>
         <site_url>{{site_url}}</site_url>
         <product_type>{{product_type}}</product_type>
         <product_type_specific>{{product_type_specific}}</product_type_specific>
@@ -45,21 +44,21 @@
         <contributors>
             {{#editors}}
             <contributor>
-                    <email/>
-                    {{#last_name}}
-                    <last_name>{{last_name}}</last_name>
-                    {{/last_name}}
-                    {{#first_name}}
-                    <first_name>{{first_name}}</first_name>
-                    {{/first_name}}
-                    {{#middle_name}}
-                    <middle_name>{{middle_name}}</middle_name>
-                    {{/middle_name}}
-                    {{#full_name}}
-                    <full_name>{{full_name}}</full_name>
-                    {{/full_name}}
-                    <contributor_type>Editor</contributor_type>
-                    <affiliations/>
+                <email/>
+                {{#last_name}}
+                <last_name>{{last_name}}</last_name>
+                {{/last_name}}
+                {{#first_name}}
+                <first_name>{{first_name}}</first_name>
+                {{/first_name}}
+                {{#middle_name}}
+                <middle_name>{{middle_name}}</middle_name>
+                {{/middle_name}}
+                {{#full_name}}
+                <full_name>{{full_name}}</full_name>
+                {{/full_name}}
+                <contributor_type>Editor</contributor_type>
+                <affiliations/>
             </contributor>
             {{/editors}}
             <contributor>
@@ -67,11 +66,9 @@
                 <contributor_type>DataCurator</contributor_type>
             </contributor>
         </contributors>
-        <!--product_nos>{{related_identifier}}</product_nos-->
         <contact_name>PDS Operator</contact_name>
         <contact_org>PDS</contact_org>
         <contact_email>pds-operator@jpl.nasa.gov</contact_email>
         <contact_phone>818.393.7165</contact_phone>
     </record>
 </records>
-

--- a/pds_doi_service/core/outputs/osti.py
+++ b/pds_doi_service/core/outputs/osti.py
@@ -1,39 +1,71 @@
+#
+#  Copyright 2020, by the California Institute of Technology.  ALL RIGHTS
+#  RESERVED. United States Government Sponsorship acknowledged. Any commercial
+#  use must be negotiated with the Office of Technology Transfer at the
+#  California Institute of Technology.
+#
 
-from os.path import dirname, join
-import pystache
+"""
+=======
+osti.py
+=======
+
+Contains classes for creating output OSTI labels from DOI objects.
+"""
+
 import copy
 import datetime
+from os.path import dirname, join
+
+import pystache
 
 from pds_doi_service.core.util.general_util import get_logger
 from pds_doi_service.core.entities.doi import Doi
 
-logger = get_logger(__name__)
+logger = get_logger('pds_doi_service.core.outputs.osti')
 
 
 class DOIOutputOsti:
     def __init__(self):
         """Creates a new DOIOutputOsti instance"""
-        # Need to find mustache templates relative to root install dir
-        self._draft_template_path = join(dirname(__file__), 'DOI_template_20200407-mustache.xml')
-        self._reserve_template_path = join(dirname(__file__), 'DOI_IAD2_reserved_template_20200205-mustache.xml')
+        # Need to find mustache templates relative to current file location
+        self._draft_template_path = join(
+            dirname(__file__), 'DOI_template_20200407-mustache.xml'
+        )
+        self._reserve_template_path = join(
+            dirname(__file__), 'DOI_IAD2_reserved_template_20200205-mustache.xml'
+        )
 
     def create_osti_doi_draft_record(self, doi: Doi):
-        # The format of 'publication_date' should match the input to 'release' action.
         doi_fields = copy.copy(doi.__dict__)
-        doi_fields['publication_date'] = doi.publication_date.strftime('%Y-%m-%d')
-        doi_fields['keywords'] = "; ".join(doi.keywords)
+
+        # It is possible that the 'publication_date' type is string if the input
+        # is string, check for it here.
+        if not isinstance(doi.publication_date, str):
+            doi_fields['publication_date'] = doi.publication_date.strftime('%Y-%m-%d')
+
+        if doi.keywords is not None:
+            doi_fields['keywords'] = "; ".join(doi.keywords)
+
         renderer = pystache.Renderer()
+
         return renderer.render_path(self._draft_template_path, doi_fields)
 
     def create_osti_doi_reserved_record(self, dois: list):
         doi_fields_list = []
+
         for doi in dois:
             doi_fields = copy.copy(doi.__dict__)
+
             logger.debug(f"convert datetime {doi_fields['publication_date']}")
-            logger.debug(f"type(doi_fields['publication_date') {type(doi_fields['publication_date'])}")
-            # It is possible that the 'publication_date' type is string if the input is string, check for it here.
-            if 'str' not in str(type(doi_fields['publication_date'])):
-                doi_fields['publication_date'] = doi_fields['publication_date'].strftime('%Y-%m-%d')
+            logger.debug(f"type(doi_fields['publication_date') "
+                         f"{type(doi_fields['publication_date'])}")
+
+            # It is possible that the 'publication_date' type is string if the
+            # input is string, check for it here.
+            if doi.publication_date and not isinstance(doi.publication_date, str):
+                doi_fields['publication_date'] = doi.publication_date.strftime('%Y-%m-%d')
+
             doi_fields_list.append(doi_fields)
 
         renderer = pystache.Renderer()
@@ -56,11 +88,15 @@ class DOIOutputOsti:
 
     def create_osti_doi_release_record(self, doi: Doi):
         doi_fields = copy.copy(doi.__dict__)
-        renderer = pystache.Renderer()
-        # Convert 'date_record_added' to proper format if value is not None, otherwise use today's date.
-        if 'date_record_added' in doi_fields and doi_fields['date_record_added'] is not None:
+
+        # Convert 'date_record_added' to proper format if value is set and not
+        # a string, otherwise use today's date.
+        if (doi_fields.get('date_record_added')
+                and not isinstance(doi_fields['date_record_added'], str)):
             doi_fields['date_record_added'] = doi_fields['date_record_added'].strftime('%Y-%m-%d')
         else:
             doi_fields['date_record_added'] = datetime.date.today().strftime('%Y-%m-%d')
+
+        renderer = pystache.Renderer()
 
         return renderer.render_path(self._draft_template_path, doi_fields)

--- a/pds_doi_service/core/outputs/osti_web_parser.py
+++ b/pds_doi_service/core/outputs/osti_web_parser.py
@@ -1,80 +1,115 @@
-#!/bin/python
 #
 #  Copyright 2020, by the California Institute of Technology.  ALL RIGHTS
 #  RESERVED. United States Government Sponsorship acknowledged. Any commercial
 #  use must be negotiated with the Office of Technology Transfer at the
 #  California Institute of Technology.
 #
-from lxml import etree
+
+"""
+==================
+osti_web_parser.py
+==================
+
+Contains classes and functions for parsing OSTI XML labels.
+"""
+
 from datetime import datetime
+from lxml import etree
 
 from pds_doi_service.core.entities.doi import Doi, DoiStatus
-from pds_doi_service.core.input.exceptions import InputFormatException
+from pds_doi_service.core.input.exceptions import InputFormatException, UnknownLIDVIDException
 from pds_doi_service.core.util.general_util import get_logger
 
 logger = get_logger('pds_doi_core.outputs.osti_web_parser')
 
+
 class DOIOstiWebParser:
-    # This class contains functions related to parsing input/output for interactions with OSTI server.
+    """
+    Contains functions related to parsing input/output for interactions with
+    the OSTI server.
+    """
+    ACCEPTABLE_FIELD_NAMES_LIST = [
+        'id', 'doi', 'accession_number', 'published_before', 'published_after',
+        'added_before', 'added_after', 'updated_before', 'updated_after',
+        'first_registered_before', 'first_registered_after', 'last_registered_before',
+        'last_registered_after', 'status', 'start', 'rows', 'sort', 'order'
+    ]
 
     def validate_field_names(self, query_dict):
-        '''Function validate the provided fields by the user to make sure they match the expected
-           fields by OSTI: https://www.osti.gov/iad2test/docs#endpoints-recordlist.'''
+        """
+        Validates the provided fields by the user to make sure they match the
+        expected fields by OSTI:
 
-        ACCEPTABLE_FIELD_NAMES_LIST = [ \
-            'id', 'doi', 'accession_number', 'published_before', 'published_after', \
-            'added_before', 'added_after', 'updated_before', 'updated_after', \
-            'first_registered_before', 'first_registered_after', 'last_registered_before', \
-            'last_registered_after', 'status', 'start', 'rows', 'sort', 'order']
+            https://www.osti.gov/iad2test/docs#endpoints-recordlist
 
+        """
         o_validated_dict = {}
 
         for key in query_dict:
             # If the key is valid, save the field and value to return.
-            if key in ACCEPTABLE_FIELD_NAMES_LIST:
-                o_validated_dict[key ] = query_dict[key]
+            if key in self.ACCEPTABLE_FIELD_NAMES_LIST:
+                o_validated_dict[key] = query_dict[key]
             else:
                 logger.error(f"Unexpected field name '{key}' in query_dict")
                 exit(1)
 
         return o_validated_dict
 
-    def parse_author_names(self,authors_element):
-        """ Given a list of authors element, parse for individual 'first_name', 'middle_name', 'last_name' or 'full_name' fields."""
+    @staticmethod
+    def parse_author_names(authors_element):
+        """
+        Given a list of author elements, parse for individual 'first_name',
+        'middle_name', 'last_name' or 'full_name' fields.
+        """
         o_authors_list = []
-        # If exist, collect all the first_name, middle_name, last_name or full_name fields into a list of dictionaries.
-        for single_author in authors_element:
-            first_name = single_author.xpath('author/first_name')
-            last_name  = single_author.xpath('author/last_name')
-            full_name  = single_author.xpath('author/full_name')
-            middle_name = single_author.xpath('author/middle_name')
 
-            author_dict = None
+        # If they exist, collect all the first name, middle name, last names or
+        # full name fields into a list of dictionaries.
+        for single_author in authors_element:
+            first_name = single_author.xpath('first_name')
+            last_name = single_author.xpath('last_name')
+            full_name = single_author.xpath('full_name')
+            middle_name = single_author.xpath('middle_name')
+
+            author_dict = {}
+
             if full_name:
-                author_dict = {'full_name': full_name[0].text}
+                author_dict['full_name'] = full_name[0].text
             else:
                 if first_name and last_name:
-                    if middle_name:
-                        author_dict = {'first_name': first_name[0].text, 'middle_name' : middle_name[0].text, 'last_name' : last_name[0].text}
-                    else:
-                        author_dict = {'first_name': first_name[0].text, 'last_name' : last_name[0].text}
+                    author_dict.update(
+                        {'first_name': first_name[0].text,
+                         'last_name': last_name[0].text}
+                    )
+
+                if middle_name:
+                    author_dict.update({'middle_name': middle_name[0].text})
+
             # It is possible that the record contains no authors.
             if author_dict:
                 o_authors_list.append(author_dict)
             else:
                 logger.warning(f"Record contains no author tag {single_author}")
+
         return o_authors_list
 
-    def parse_contributor_names(self,contributors_element):
-        """ Given a list of contributors element, parse for individual 'full_name' fields."""
+    @staticmethod
+    def parse_contributor_names(contributors_element):
+        """
+        Given a list of contributors elements, parse for individual 'full_name'
+        fields.
+        """
         o_contributors_list = []
-        # If exist, collect all the first_name, middle_name, last_name or full_name fields into a list of dictionaries.
-        for single_contributor in contributors_element:
-            full_name  = single_contributor.xpath('contributor/full_name')
 
-            contributor_dict = None
+        # If they exist, collect all the contributor name fields into a list of dictionaries.
+        for single_contributor in contributors_element:
+            full_name = single_contributor.xpath('full_name')
+
+            contributor_dict = {}
+
             if full_name:
-                contributor_dict = {'full_name': full_name[0].text}
+                contributor_dict['full_name'] = full_name[0].text
+
             # It is possible that the record contains no contributor.
             if contributor_dict:
                 o_contributors_list.append(contributor_dict)
@@ -83,7 +118,8 @@ class DOIOstiWebParser:
 
         return o_contributors_list
 
-    def parse_optional_fields(self, io_doi, single_record_element):
+    @staticmethod
+    def parse_optional_fields(io_doi, single_record_element):
         """
         Given a single record element, parse the following optional fields which
         may not be present from the OSTI response:
@@ -92,77 +128,33 @@ class DOIOstiWebParser:
             'doi_message', 'authors'.
 
         """
-        io_doi.id = None  # Need to set to None so the field can be accessed.
+        optional_fields = ['id', 'doi', 'sponsoring_organization',
+                           'publisher', 'availability', 'country',
+                           'description', 'site_url', 'site_code',
+                           'date_record_added', 'date_record_updated',
+                           'keywords', 'authors', 'contributors']
 
-        if single_record_element.xpath('id'):
-            io_doi.id = single_record_element.xpath('id')[0].text
-            logger.debug(f"Adding optional field 'id' {io_doi.id}")
+        for optional_field in optional_fields:
+            optional_field_element = single_record_element.xpath(optional_field)
 
-        if single_record_element.xpath('site_url'):
-            io_doi.site_url = single_record_element.xpath('site_url')[0].text
-            logger.debug(f"Adding optional field 'site_url' {io_doi.site_url}")
-
-        if single_record_element.xpath('doi'):
-            io_doi.doi = single_record_element.xpath('doi')[0].text
-            logger.debug(f"Adding optional field 'doi' {io_doi.doi}")
-
-        if single_record_element.xpath('date_record_added'):
-            date_record_added_element = single_record_element.xpath('date_record_added')[0]
-
-            # Check for empty tag
-            if date_record_added_element.text:
-                # It is possible have bad date format.
-                try:
-                    io_doi.date_record_added = datetime.fromisoformat(
-                        date_record_added_element.text
+            if optional_field_element:
+                if optional_field == 'keywords' and optional_field_element[0].text is not None:
+                    io_doi.keywords = optional_field_element[0].text.split('; ')
+                elif optional_field == 'authors':
+                    io_doi.authors = DOIOstiWebParser.parse_author_names(
+                        optional_field_element[0]
                     )
-
-                    logger.debug("Adding optional field 'date_record_added' "
-                                 f"{io_doi.date_record_added}")
-                except Exception:
-                    msg = ("Cannot parse field 'date_record_added'. "
-                           "Expecting format '%Y-%m-%d'. "
-                           f"Received {date_record_added_element.text}.")
-                    logger.error(msg)
-                    raise InputFormatException(msg)
-
-        if single_record_element.xpath('date_record_updated'):
-            date_record_updated_element = single_record_element.xpath('date_record_updated')[0]
-
-            # Check for empty tag
-            if date_record_updated_element.text:
-                # It is possible have bad date format.
-                try:
-                    io_doi.date_record_updated = datetime.fromisoformat(
-                        date_record_updated_element.text
+                elif optional_field == 'contributors':
+                    io_doi.contributors = DOIOstiWebParser.parse_contributor_names(
+                        optional_field_element[0]
                     )
+                else:
+                    setattr(io_doi, optional_field, optional_field_element[0].text)
 
-                    logger.debug("Adding optional field 'date_record_updated' "
-                                 f"{io_doi.date_record_updated}")
-                except Exception:
-                    msg = ("Cannot parse field 'date_record_updated'. "
-                           "Expecting format '%Y-%m-%d'. "
-                           f"Received {date_record_updated_element.text}")
-                    logger.error(msg)
-                    raise InputFormatException(msg)
-
-        if single_record_element.xpath('doi_message'):
-            io_doi.message = single_record_element.xpath('doi_message')[0].text
-            logger.debug(f"Adding optional field 'doi_message' {io_doi.message}")
-
-        if single_record_element.xpath('authors'):
-            io_doi.authors = DOIOstiWebParser().parse_author_names(
-                single_record_element.xpath('authors')
-            )
-            logger.debug(f"Adding optional field 'authors' {io_doi.authors}")
-
-        if single_record_element.xpath('contributors'):
-            io_doi.contributors = DOIOstiWebParser().parse_contributor_names(
-                single_record_element.xpath('contributors')
-            )
-            logger.debug(f"Adding optional field 'contributors' {io_doi.contributors}")
-
-        io_doi.related_identifier = DOIOstiWebParser.get_lidvid(single_record_element)
+                logger.debug(
+                    f"Adding optional field "
+                    f"'{optional_field}': {getattr(io_doi, optional_field)}"
+                )
 
         logger.debug(f"io_doi) {io_doi}")
 
@@ -170,21 +162,34 @@ class DOIOstiWebParser:
 
     @staticmethod
     def get_lidvid_from_site_url(record):
-        # For some record, the lidvid can be parsed from site_url as a last resort.
-        #<site_url>https://pds.jpl.nasa.gov/ds-view/pds/viewBundle.jsp?identifier=urn%3Anasa%3Apds%3Ainsight_cameras&amp;version=1.0</site_url>
+        """
+        For some records, the lidvid can be parsed from site_url as a last resort.
+
+        Ex:
+            https://pds.jpl.nasa.gov/ds-view/pds/viewBundle.jsp?identifier=urn%3Anasa%3Apds%3Ainsight_cameras&amp;version=1.0
+
+        """
         site_url = record.xpath("site_url")[0].text
         site_tokens = site_url.split("identifier=")
-        identifier_tokens = site_tokens[1].split(";")
-        lid_vid_tokens = identifier_tokens[0].split("&version=")
-        lid_value = lid_vid_tokens[0].replace("%3A",":")
-        vid_value = lid_vid_tokens[1]
-        lid_vid_value = lid_value + '::' + vid_value # Finally combine the lid and vid together.
 
-        return  lid_value + '::' + vid_value
+        identifier_tokens = site_tokens[1].split(";")
+
+        lid_vid_tokens = identifier_tokens[0].split("&version=")
+        lid_value = lid_vid_tokens[0].replace("%3A", ":")
+        vid_value = lid_vid_tokens[1]
+
+        # Finally combine the lid and vid together.
+        lid_vid_value = lid_value + '::' + vid_value
+
+        return lid_vid_value
 
     @staticmethod
     def get_lidvid(record):
-        # Depending on versions, lidvid has been stored in different locations
+        """
+        Depending on versions, a lidvid can be stored in different locations.
+        This function searches each location, and returns the first encountered
+        LIDVID.
+        """
         if record.xpath("accession_number"):
             return record.xpath("accession_number")[0].text
         elif record.xpath("related_identifiers/related_identifier[./identifier_type='URL']"):
@@ -201,9 +206,9 @@ class DOIOstiWebParser:
             return lid_vid_value
         else:
             # For now, do not consider it an error if cannot get the lidvid.
-            logger.debug(f"Cannot find identifier_value.  Expecting one of ['accession_number','identifier_type','report_numbers'] tags")
+            logger.debug("Cannot find identifier_value. "
+                         "Expecting one of ['accession_number','identifier_type','report_numbers'] tags")
             return None
-            #raise InputFormatException("Cannot find identifier_value.  Expecting one of ['accession_number','identifier_type','report_numbers'] tags")
 
     @staticmethod
     def get_record_for_lidvid(osti_label_file, lidvid):
@@ -261,8 +266,8 @@ class DOIOstiWebParser:
         By default, all possible fields are extracted. If desire to only extract
         smaller set of fields, they should be specified accordingly.
         Specific fields are extracted from input. Not all fields in XML are used.
-        """
 
+        """
         dois = []
         errors = []
 
@@ -270,9 +275,16 @@ class DOIOstiWebParser:
         my_root = doc.getroottree()
 
         # Trim down input to just fields we want.
-        for single_record_element in my_root.findall('record'):
+        for index, single_record_element in enumerate(my_root.findall('record')):
             status = single_record_element.get('status')
-            if status is not None and status.lower() == 'error':
+
+            if status is None:
+                raise InputFormatException(
+                    f'Could not parse a status for record {index + 1} from the '
+                    f'provided OSTI XML.'
+                )
+
+            if status.lower() == 'error':
                 # The 'error' record is parsed differently and does not have all
                 # the attributes we desire.
                 # Get the entire text and save it in 'error' key. Print a WARN
@@ -288,40 +300,53 @@ class DOIOstiWebParser:
                         errors.append(error_element.text)
             else:
                 lidvid = DOIOstiWebParser.get_lidvid(single_record_element)
+
                 if lidvid:
                     # Move the fetching of identifier_type in parse_optional_fields() function.
                     # The following 4 fields were deleted from constructor of Doi
                     # to inspect individually since the code was failing:
                     #     ['id','doi','date_record_added',date_record_updated']
-                    doi = Doi(title=single_record_element.xpath('title')[0].text,
-                              publication_date=single_record_element.xpath('publication_date')[0].text,
-                              product_type=single_record_element.xpath('product_type')[0].text,
-                              product_type_specific=single_record_element.xpath('product_type_specific')[0].text,
-                              related_identifier=lidvid,  # Set to None here and will be set to a valid value later.
-                              status=DoiStatus(status.lower()))
+                    doi = Doi(
+                        title=single_record_element.xpath('title')[0].text,
+                        publication_date=single_record_element.xpath('publication_date')[0].text,
+                        product_type=single_record_element.xpath('product_type')[0].text,
+                        product_type_specific=single_record_element.xpath('product_type_specific')[0].text,
+                        related_identifier=lidvid,
+                        status=DoiStatus(status.lower())
+                    )
 
-                    # Parse for some optional fields that may not be present in every record from OSTI.
-                    doi= DOIOstiWebParser().parse_optional_fields(doi, single_record_element)
+                    # Parse for some optional fields that may not be present in
+                    # every record from OSTI.
+                    doi = DOIOstiWebParser.parse_optional_fields(doi, single_record_element)
+
                     dois.append(doi)
                 else:
-                    logger.warning(f"no lidvid reference found in doi {single_record_element.xpath('doi')[0].text}")
+                    logger.warning(
+                        f"No lidvid reference found in DOI "
+                        f"{single_record_element.xpath('doi')[0].text}"
+                    )
 
-        # end for single_record_element in my_root.findall('record'):
+        # end for index, single_record_element in enumerate(my_root.findall('record')):
 
         return dois, errors
 
-    def response_get_parse_osti_json(self,osti_response):
-        """Function parse a response from a query to the OSTI server (in JSON format) and return a JSON object.
-           Specific fields are extracted from input.  Not all fields in JSON are used."""
+    @staticmethod
+    def response_get_parse_osti_json(osti_response):
+        """
+        Parses a response from a query to the OSTI server (in JSON format) and
+        returns a JSON object.
 
+        Specific fields are extracted from input. Not all fields in JSON are used.
+
+        """
         dois = []  # It is possible that the query resulted in no rows.
 
         # These are the fields in a record returned by OSTI
-        # fields_returned_from_osti = \
-        #    ['id','site_code','title' 'sponsoring_organization', 'accession_number', 'doi',\
-        #     'authors', 'status', 'publisher', 'availability', 'publication_date', 'country',\
-        #     'description', 'site_url', 'product_type', 'product_type_specific',\
-        #     'related_identifiers', 'date_record_added', 'date_record_updated',\
+        # fields_returned_from_osti =
+        #    ['id','site_code','title' 'sponsoring_organization', 'accession_number', 'doi',
+        #     'authors', 'status', 'publisher', 'availability', 'publication_date', 'country',
+        #     'description', 'site_url', 'product_type', 'product_type_specific',
+        #     'related_identifiers', 'date_record_added', 'date_record_updated',
         #     'keywords', 'doi_message']
 
         for record in osti_response['records']:
@@ -335,10 +360,12 @@ class DOIOstiWebParser:
                       doi=record['doi'],
                       date_record_added=record['date_record_added'],
                       date_record_updated=record['date_record_updated'])
+
             if 'doi_message' in record:
                 doi.message = record['doi_message']
 
             dois.append(doi)
 
         return dois
+
 # end class DOIOstiWebParser

--- a/pds_doi_service/core/outputs/osti_web_parser.py
+++ b/pds_doi_service/core/outputs/osti_web_parser.py
@@ -206,6 +206,53 @@ class DOIOstiWebParser:
             #raise InputFormatException("Cannot find identifier_value.  Expecting one of ['accession_number','identifier_type','report_numbers'] tags")
 
     @staticmethod
+    def get_record_for_lidvid(osti_label_file, lidvid):
+        """
+        Returns the record entry corresponding to the provided LIDVID from the
+        OSTI XML label file.
+
+        Parameters
+        ----------
+        osti_label_file : str
+            Path to the OSTI XML label file to search.
+        lidvid : str
+            The LIDVID of the record to return from the OSTI label.
+
+        Returns
+        -------
+        record : str
+            The single found record embedded in a <records> tag. This string is
+            suitable to be written to disk as a new OSTI label.
+
+        Raises
+        ------
+        UnknownLIDVIDException
+            If no record for the requested LIDVID is found in the provided OSTI
+            label file.
+
+        """
+        root = etree.parse(osti_label_file).getroot()
+
+        records = root.xpath('record')
+
+        for record in records:
+            if DOIOstiWebParser.get_lidvid(record) == lidvid:
+                result = record
+                break
+        else:
+            raise UnknownLIDVIDException(
+                f'Could not find entry for lidvid "{lidvid}" in OSTI label file '
+                f'{osti_label_file}.'
+            )
+
+        new_root = etree.Element('records')
+        new_root.append(result)
+
+        return etree.tostring(
+            new_root, pretty_print=True, xml_declaration=True, encoding='UTF-8'
+        ).decode('utf-8')
+
+    @staticmethod
     def response_get_parse_osti_xml(osti_response_text):
         """
         Parses a response from a GET (query) or a PUT to the OSTI server


### PR DESCRIPTION
**Summary**
This PR adds a new "submit" endpoint to the DOI API for moving a record from draft/reserve to "review" status. The previous "release" endpoint has been (temporarily) removed to ensure Engineering Node has final say over release of a DOI. To move a record back to draft from review, a `--lidvid` option has been added to the Draft action to reset the workflow status associated to a LIDVID back to draft/pending.

This branch also rolls up a number of bug fixes, code refactors and cleanup which were deemed necessary during the development of the above features.

**Test Data and/or Report**
Unit tests have been added for the new submit endpoint, as well as to ensure that the release endpoint is no longer reachable by the API. A number of existing unit tests for the reserve endpoint have been disabled (marked with skip decorator) for the time being as well.

Likewise, a unit test has been added for the Draft --lidvid option, and the test case for the Draft action has been rewritten to check the results returned from the calls to `run()`
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/5875759/test.txt)


**Related Issues**
#134 #135 