### PR TITLE
Endpoint Strict Slash Checking Disable

### DIFF
--- a/pds_doi_service/api/__main__.py
+++ b/pds_doi_service/api/__main__.py
@@ -11,6 +11,9 @@ def main():
     app = connexion.App(__name__, specification_dir='swagger/')
     CORS(app.app)
     app.app.json_encoder = encoder.JSONEncoder
+    # Disable the Flask "strict_slashes" checking so endpoints with a trailing
+    # slash resolve to the same endpoint as without
+    app.app.url_map.strict_slashes = False
     app.add_api('swagger.yaml',
                 arguments={'title': 'Planetary Data System DOI Service API'},
                 pythonic_params=True)

--- a/pds_doi_service/api/test/__init__.py
+++ b/pds_doi_service/api/test/__init__.py
@@ -12,5 +12,6 @@ class BaseTestCase(TestCase):
         logging.getLogger('connexion.operation').setLevel('ERROR')
         app = connexion.App(__name__, specification_dir='../swagger/')
         app.app.json_encoder = JSONEncoder
+        app.app.url_map.strict_slashes = False
         app.add_api('swagger.yaml')
         return app.app

--- a/pds_doi_service/api/test/test_dois_controller.py
+++ b/pds_doi_service/api/test/test_dois_controller.py
@@ -52,19 +52,24 @@ class TestDoisController(BaseTestCase):
         # Start with a empty query to fetch all available records
         query_string = [('db_name', test_db)]
 
-        response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
-                                    method='GET',
-                                    query_string=query_string)
+        # Ensure fetch-all endpoint works both with and without a trailing
+        # slash
+        endpoints = ['/PDS_APIs/pds_doi_api/0.1/dois',
+                     '/PDS_APIs/pds_doi_api/0.1/dois/']
 
-        self.assert200(
-            response,
-            'Response body is : ' + response.data.decode('utf-8')
-        )
+        for endpoint in endpoints:
+            response = self.client.open(endpoint, method='GET',
+                                        query_string=query_string)
 
-        records = response.json
+            self.assert200(
+                response,
+                'Response body is : ' + response.data.decode('utf-8')
+            )
 
-        # Test database should contain 3 records
-        self.assertEqual(len(records), 3)
+            records = response.json
+
+            # Test database should contain 3 records
+            self.assertEqual(len(records), 3)
 
         # Now use a query string to ensure we can get specific records back
         query_string = [('node', 'eng'),


### PR DESCRIPTION

**Summary***
This PR updates the initialization of the Flask/Connexion app used in the DOI API to set the "strict_slashes" flag to False.
This allows endpoints such as `/dois` and `/dois/` to resolve to the same place.

**Test Data and/or Report**
Updated unit test for /dois endpoint to ensure that using a trailing slash also works.
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/5914896/test.txt)

**Related Issues**
Reference related issues here and use `Fixes` or `Resolves` for closing issues:
#141 