### PR TITLE
Draft Action Support for OSTI Label Input

### DIFF
--- a/input/DOI_Release_20200727_from_draft.xml
+++ b/input/DOI_Release_20200727_from_draft.xml
@@ -1,81 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <records>
-    <record status='Pending'>
+    <record status='pending'>
+        <id/>
         <title>InSight Cameras Bundle 0</title>
+        <sponsoring_organization>National Aeronautics and Space Administration (NASA)</sponsoring_organization>
         <accession_number>urn:nasa:pds:insight_cameras::2.0</accession_number>
-        <authors>
-             <author>
-                <first_name>R.</first_name>
-                <last_name>Deen</last_name>
-            </author>
-             <author>
-                <first_name>H.</first_name>
-                <last_name>Abarca</last_name>
-            </author>
-             <author>
-                <first_name>P.</first_name>
-                <last_name>Zamani</last_name>
-            </author>
-             <author>
-                <first_name>J.</first_name>
-                <last_name>Maki</last_name>
-            </author>
-        </authors>
         <publisher>NASA Planetary Data System</publisher>
+        <availability>NASA Planetary Data System</availability>
         <publication_date>2019-01-01</publication_date>
+        <description>InSight Cameras Experiment Data Record (EDR) and Reduced Data Record (RDR) Data Products</description>
         <site_url>https://pds.jpl.nasa.gov/ds-view/pds/viewBundle.jsp?identifier=urn%3Anasa%3Apds%3Ainsight_cameras&amp;version=1.0</site_url>
-        <!-- Collection definition:
-                a Collection product may refer to an aggregation of resources and research objects.
-                A Collection probably has items in it which have or will receive their own DOIs and thus be
-                retrievable independently. Therefore the Collection record is a high-level description of
-                the overall group of items.
-        -->
         <product_type>Dataset</product_type>
         <product_type_specific>PDS4 Refereed Data Bundle</product_type_specific>
-
-        <description>InSight Cameras Experiment Data Record (EDR) and Reduced Data Record (RDR) Data Products
-        </description>
-        <keywords>PDS; Instrument; Spacecraft; Raw; Lander; Mars; Deployment; Science; Mission; Camera; Insight; Context; Planet</keywords>
-
-        <related_resource></related_resource>
-        <contributor_organizations></contributor_organizations>
-        <sponsor_org>National Aeronautics and Space Administration (NASA)</sponsor_org>
-        <contract_nos></contract_nos>
-        <other_identifying_nos></other_identifying_nos>
-        <file_extension></file_extension>
-        <availability>NSSDCA</availability>
-        <contact_name>PDS Operator</contact_name>
-        <contact_org>PDS</contact_org>
-        <contact_email>pds-operator@jpl.nasa.gov</contact_email>
-        <contact_phone>818.393.7165</contact_phone>
+        <keywords>PDS;Instrument;Spacecraft;Raw;Lander;Mars;Deployment;Science;Mission;Camera;Insight;Context;Planet</keywords>
+        <authors>
+            <author>
+                <last_name>Deen</last_name>
+                <first_name>R.</first_name>
+            </author>
+            <author>
+                <last_name>Abarca</last_name>
+                <first_name>H.</first_name>
+            </author>
+            <author>
+                <last_name>Zamani</last_name>
+                <first_name>P.</first_name>
+            </author>
+            <author>
+                <last_name>Maki</last_name>
+                <first_name>J.</first_name>
+            </author>
+        </authors>
         <contributors>
             <contributor>
-                    <email/>
-                    <first_name>P. H.</first_name>
-                    <last_name>Smith</last_name>
-                    <contributor_type>Editor</contributor_type>
-                    <affiliations/>
+                <email/>
+                <last_name>Smith</last_name>
+                <first_name>P. H.</first_name>
+                <contributor_type>Editor</contributor_type>
+                <affiliations/>
             </contributor>
             <contributor>
-                    <email/>
-                    <first_name>M.</first_name>
-                    <last_name>Lemmon</last_name>
-                    <contributor_type>Editor</contributor_type>
-                    <affiliations/>
+                <email/>
+                <last_name>Lemmon</last_name>
+                <first_name>M.</first_name>
+                <contributor_type>Editor</contributor_type>
+                <affiliations/>
             </contributor>
             <contributor>
-                    <email/>
-                    <first_name>R. F.</first_name>
-                    <last_name>Beebe</last_name>
-                    <contributor_type>Editor</contributor_type>
-                    <affiliations/>
+                <email/>
+                <last_name>Beebe</last_name>
+                <first_name>R. F.</first_name>
+                <contributor_type>Editor</contributor_type>
+                <affiliations/>
             </contributor>
             <contributor>
                 <full_name>PDS Cartography and Imaging Sciences Discipline</full_name>
                 <contributor_type>DataCurator</contributor_type>
             </contributor>
         </contributors>
+        <contact_name>PDS Operator</contact_name>
+        <contact_org>PDS</contact_org>
+        <contact_email>pds-operator@jpl.nasa.gov</contact_email>
+        <contact_phone>818.393.7165</contact_phone>
     </record>
 </records>
-
-

--- a/input/DOI_Release_20200727_from_reserve.xml
+++ b/input/DOI_Release_20200727_from_reserve.xml
@@ -1,65 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <records>
-  <record status='pending' index="1">
-    <id>25901</id>
-    <site_url>http://mysite.example.com/link/to/my-dataset-id-25901.html</site_url>
-    <site_code>NASA-PDS</site_code>
-    <title>Laboratory Shocked Feldspars Bundle</title>
-    <accession_number>urn:nasa:pds:lab_shocked_feldspars::2.0</accession_number>
-    <doi>10.17189/25901</doi>
-    <publication_date>2020-03-11</publication_date>
-    <product_type>Dataset</product_type>
-    <product_type_specific>PDS4 Refereed Data Bundle</product_type_specific>
-    <date_record_added>2020-07-23</date_record_added>
-    <date_record_updated>2020-07-23</date_record_updated>
-    <authors>
-      <author>
-        <first_name>J. R.</first_name>
-        <last_name>Johnson</last_name>
-        <affiliations/>
-      </author>
-    </authors>
-    <contributors/>
-  </record>
-  <record  status='pending' index="2">
-    <id>25902</id>
-    <site_url>http://mysite.example.com/link/to/my-dataset-id-25902.html</site_url>
-    <site_code>NASA-PDS</site_code>
-    <title>Laboratory Shocked Feldspars Bundle 2</title>
-    <accession_number>urn:nasa:pds:lab_shocked_feldspars_2::1.0</accession_number>
-    <doi>10.17189/25902</doi>
-    <publication_date>2020-03-12</publication_date>
-    <product_type>Dataset</product_type>
-    <product_type_specific>PDS4 Refereed Data Bundle</product_type_specific>
-    <date_record_added>2020-07-23</date_record_added>
-    <date_record_updated>2020-07-23</date_record_updated>
-    <authors>
-      <author>
-        <first_name>J2. R2.</first_name>
-        <last_name>Johnson_2</last_name>
-        <affiliations/>
-      </author>
-    </authors>
-    <contributors/>
-  </record>
-  <record status='pending' index="3">
-    <id>25903</id>
-    <site_url>http://mysite.example.com/link/to/my-dataset-id-25903.html</site_url>
-    <site_code>NASA-PDS</site_code>
-    <title>Laboratory Shocked Feldspars Bundle</title>
-    <accession_number>urn:nasa:pds:lab_shocked_feldspars_3::1.0</accession_number>
-    <doi>10.17189/25903</doi>
-    <publication_date>2020-03-12</publication_date>
-    <product_type>Dataset</product_type>
-    <product_type_specific>PDS4 Refereed Data Bundle</product_type_specific>
-    <date_record_added>2020-07-23</date_record_added>
-    <date_record_updated>2020-07-23</date_record_updated>
-    <authors>
-      <author>
-        <first_name>J3. R3.</first_name>
-        <last_name>Johnson_3</last_name>
-        <affiliations/>
-      </author>
-    </authors>
-    <contributors/>
-  </record>
+    <record status='pending'>
+        <id>25901</id>
+        <title>Laboratory Shocked Feldspars Bundle</title>
+        <doi>10.17189/25901</doi>
+        <accession_number>urn:nasa:pds:lab_shocked_feldspars::2.0</accession_number>
+        <availability>NASA Planetary Data System</availability>
+        <publication_date>2020-03-11</publication_date>
+        <site_url>http://mysite.example.com/link/to/my-dataset-id-25901.html</site_url>
+        <site_code>NASA-PDS</site_code>
+        <product_type>Dataset</product_type>
+        <product_type_specific>PDS4 Refereed Data Bundle</product_type_specific>
+        <date_record_added>2020-07-23</date_record_added>
+        <date_record_updated>2020-07-23</date_record_updated>
+        <keywords>PDS;PDS4</keywords>
+        <authors>
+            <author>
+                <last_name>Johnson</last_name>
+                <first_name>J. R.</first_name>
+                <affiliations/>
+            </author>
+        </authors>
+        <contributors/>
+        <contact_name>PDS Operator</contact_name>
+        <contact_org>PDS</contact_org>
+        <contact_email>pds-operator@jpl.nasa.gov</contact_email>
+        <contact_phone>818.393.7165</contact_phone>
+    </record>
 </records>

--- a/input/DOI_Release_20200727_from_review.xml
+++ b/input/DOI_Release_20200727_from_review.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <records>
     <record status="review">
-        <id></id>
+        <id/>
         <title>InSight Cameras Bundle 0</title>
         <sponsoring_organization>National Aeronautics and Space Administration (NASA)</sponsoring_organization>
         <accession_number>urn:nasa:pds:insight_cameras::2.0</accession_number>
-        <publisher></publisher>
-        <availability></availability>
+        <publisher>NASA Planetary Data System</publisher>
+        <availability>NASA Planetary Data System</availability>
         <publication_date>2019-01-01</publication_date>
         <site_url>https://pds.jpl.nasa.gov/ds-view/pds/viewBundle.jsp?identifier=urn%3Anasa%3Apds%3Ainsight_cameras&amp;version=1.0</site_url>
         <product_type>Dataset</product_type>
         <product_type_specific>PDS4 Refereed Data Bundle</product_type_specific>
-        <date_record_added></date_record_added>
-        <keywords>PDS; PDS4;</keywords>
+        <date_record_added>2020-07-23</date_record_added>
+        <keywords>PDS;PDS4</keywords>
         <authors>
             <author>
-                <first_name>R.</first_name>
                 <last_name>Deen</last_name>
+                <first_name>R.</first_name>
             </author>
-             <author>
-                <first_name>H.</first_name>
-                <last_name>Abarca</last_name>
+            <author>
+                 <last_name>Abarca</last_name>
+                 <first_name>H.</first_name>
             </author>
-             <author>
-                <first_name>P.</first_name>
+            <author>
                 <last_name>Zamani</last_name>
+                <first_name>P.</first_name>
             </author>
-             <author>
-                <first_name>J.</first_name>
+            <author>
                 <last_name>Maki</last_name>
+                <first_name>J.</first_name>
             </author>
         </authors>
         <contributors>

--- a/pds_doi_service/api/controllers/dois_controller.py
+++ b/pds_doi_service/api/controllers/dois_controller.py
@@ -317,9 +317,7 @@ def post_dois(action, submitter, node, url=None, body=None, force=False):
         return format_exceptions(err), 500
 
     # Parse the OSTI XML string back into a list of DOIs
-    dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(
-        bytes(osti_label, encoding='utf-8')
-    )
+    dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(osti_label)
 
     records = _records_from_dois(
         dois, node=node, submitter=submitter, osti_record=osti_label
@@ -414,9 +412,7 @@ def post_release_doi(lidvid, force=False, **kwargs):
 
             osti_release_label = release_action.run(**release_kwargs)
 
-        dois, errors = DOIOstiWebParser().response_get_parse_osti_xml(
-            bytes(osti_release_label, encoding='utf-8')
-        )
+        dois, errors = DOIOstiWebParser().response_get_parse_osti_xml(osti_release_label)
 
         # Propagate any errors returned from OSTI in a single exception
         if errors:
@@ -499,9 +495,7 @@ def get_doi_from_id(lidvid):  # noqa: E501
         return format_exceptions(err), 500
 
     # Parse the label associated with the lidvid so we can return a full DoiRecord
-    dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(
-        bytes(osti_label_for_lidvid, encoding='utf-8')
-    )
+    dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(osti_label_for_lidvid)
 
     records = _records_from_dois(
         dois, node=list_record['node_id'], submitter=list_record['submitter'],

--- a/pds_doi_service/api/controllers/dois_controller.py
+++ b/pds_doi_service/api/controllers/dois_controller.py
@@ -242,8 +242,8 @@ def post_dois(action, submitter, node, url=None, body=None, force=False):
         the action is set to "reserve", otherwise it can be used optionally in
         lieu of url when the action is set to "draft".
     force : bool
-        If true, forces a reserve request to completion, ignoring any warnings
-        encountered. Has no effect for draft requests.
+        If true, forces a request to completion, ignoring any warnings
+        encountered.
 
     Returns
     -------
@@ -293,7 +293,8 @@ def post_dois(action, submitter, node, url=None, body=None, force=False):
                     draft_kwargs = {
                         'node': node,
                         'submitter': submitter,
-                        'input': xml_file.name
+                        'input': xml_file.name,
+                        'force': force
                     }
 
                     osti_label = draft_action.run(**draft_kwargs)
@@ -301,7 +302,8 @@ def post_dois(action, submitter, node, url=None, body=None, force=False):
                 draft_kwargs = {
                     'node': node,
                     'submitter': submitter,
-                    'input': url
+                    'input': url,
+                    'force': force
                 }
 
                 osti_label = draft_action.run(**draft_kwargs)

--- a/pds_doi_service/core/actions/draft.py
+++ b/pds_doi_service/core/actions/draft.py
@@ -15,7 +15,6 @@ Contains the definition for the Draft action of the Core PDS DOI Service.
 
 import copy
 import os
-import requests
 from lxml import etree
 from os.path import exists, join
 
@@ -31,9 +30,9 @@ from pds_doi_service.core.input.exceptions import (UnknownNodeException,
                                                    CriticalDOIException,
                                                    collect_exception_classes_and_messages,
                                                    raise_or_warn_exceptions)
+from pds_doi_service.core.input.input_util import DOIInputUtil
 from pds_doi_service.core.input.node_util import NodeUtil
 from pds_doi_service.core.input.osti_input_validator import OSTIInputValidator
-from pds_doi_service.core.input.pds4_util import DOIPDS4LabelUtil
 from pds_doi_service.core.outputs.osti import DOIOutputOsti
 from pds_doi_service.core.outputs.osti_web_parser import DOIOstiWebParser
 from pds_doi_service.core.util.doi_validator import DOIValidator
@@ -68,14 +67,14 @@ class DOICoreActionDraft(DOICoreAction):
     def add_to_subparser(cls, subparsers):
         action_parser = subparsers.add_parser(
             cls._name, description='Create a draft of OSTI records, '
-                                   'from a single or list of PDS4 labels'
+                                   'from existing PDS4 or OSTI labels'
         )
 
         node_values = NodeUtil.get_permissible_values()
         action_parser.add_argument(
             '-i', '--input', required=False,
             metavar='input/bundle_in_with_contributors.xml',
-            help='An input PDS4 label. May be a local path or an HTTP address '
+            help='An input PDS4/OSTI label. May be a local path or an HTTP address '
                  'resolving to a label file. Multiple inputs may be provided '
                  'via comma-delimited list. Must be provided if --lidvid is not '
                  'specified.'
@@ -161,9 +160,7 @@ class DOICoreActionDraft(DOICoreAction):
         )
 
         # Format label into an in-memory DOI object
-        dois, errors = DOIOstiWebParser.response_get_parse_osti_xml(
-            bytes(lidvid_record, encoding='utf-8')
-        )
+        dois, errors = DOIOstiWebParser.response_get_parse_osti_xml(lidvid_record)
 
         doi = dois[0]
 
@@ -298,70 +295,44 @@ class DOICoreActionDraft(DOICoreAction):
 
         return io_doi
 
-    def _transform_pds4_label_into_osti_record(self, input_file, keywords):
+    def _transform_label_into_osti_record(self, input_file, keywords):
         """
         Receives an XML PDS4 input file and transforms it into an OSTI record.
         """
-        # Set to None to signify an input file that does not end with '.xml'
-        o_doi_label = None
-        o_doi = None
+        input_util = DOIInputUtil(valid_extensions=['.xml'])
 
-        # parse input_file
-        if not input_file.startswith('http'):
-            # Only process .xml files and print WARNING for any other files,
-            # then continue.
-            if input_file.endswith('.xml'):
-                try:
-                    xml_tree = etree.parse(input_file)
-                except OSError as err:
-                    msg = f'Error reading file {input_file}, reason: {str(err)}'
-                    logger.error(msg)
-                    raise InputFormatException(msg)
-            else:
-                msg = f"File {input_file} was not processed, only .xml files " \
-                      "are supported"
-                logger.warning(msg)
-                return o_doi_label, o_doi
+        o_dois = input_util.parse_dois_from_input_file(input_file)
 
-        else:
-            # A URL gets read into memory.
-            response = requests.get(input_file)
-            xml_tree = etree.fromstring(response.content)
+        for o_doi in o_dois:
+            o_doi.publisher = self._config.get('OTHER', 'doi_publisher')
+            o_doi.contributor = NodeUtil().get_node_long_name(self._node)
 
-        label_util = DOIPDS4LabelUtil(
-            landing_page_template=self._config.get('LANDING_PAGES', 'url')
-        )
+            # Add 'status' field so the ranking in the workflow can be determined.
+            o_doi.status = DoiStatus.Draft
 
-        o_doi = label_util.get_doi_fields_from_pds4(xml_tree)
-        o_doi.publisher = self._config.get('OTHER', 'doi_publisher')
-        o_doi.contributor = NodeUtil().get_node_long_name(self._node)
-
-        # Add 'status' field so the ranking in the workflow can be determined.
-        o_doi.status = DoiStatus.Draft
-
-        # Add any default keywords or extra keywords provided by the user.
-        self._add_extra_keywords(keywords, o_doi)
+            # Add any default keywords or extra keywords provided by the user.
+            self._add_extra_keywords(keywords, o_doi)
 
         # Generate the output OSTI record
-        o_doi_label = DOIOutputOsti().create_osti_doi_record(o_doi)
+        o_doi_label = DOIOutputOsti().create_osti_doi_record(o_dois)
 
-        # Return the label (which is text) and a dictionary 'o_doi' representing
-        # all values parsed.
-        return o_doi_label, o_doi
+        # Return the label (which is text) and a dictionary 'o_dois' representing
+        # all individual DOI's parsed.
+        return o_doi_label, o_dois
 
     def _run_single_file(self, input_file, node, submitter, force_flag, keywords):
         exception_classes = []
         exception_messages = []
 
         doi_label = None
-        doi_obj = None
+        dois_obj = None
 
         logger.info(f"input_file {input_file}")
         logger.debug(f"force_flag,input_file {force_flag, input_file}")
 
         try:
-            # Transform the PDS4 label to an OSTI record.
-            doi_label, doi_obj = self._transform_pds4_label_into_osti_record(
+            # Transform the input label to an OSTI record and list of Doi objects.
+            doi_label, dois_obj = self._transform_label_into_osti_record(
                 input_file, keywords
             )
 
@@ -374,7 +345,7 @@ class DOICoreActionDraft(DOICoreAction):
                 if self._config.get('OTHER', 'draft_validate_against_xsd_flag').lower() == 'true':
                     self._doi_validator.validate_against_xsd(doi_label)
 
-            if doi_obj:
+            for doi_obj in dois_obj:
                 self._doi_validator.validate(doi_obj)
         # Collect any exceptions/warnings for now and decide whether to
         # raise or log them later on
@@ -393,13 +364,13 @@ class DOICoreActionDraft(DOICoreAction):
         # depending on the the state of the force flag
         if len(exception_classes) > 0:
             raise_or_warn_exceptions(exception_classes, exception_messages,
-                                     log=self._force)
+                                     log=force_flag)
 
-        if doi_label and doi_obj:
+        if doi_label and dois_obj:
             # Use the service of TransactionBuilder to prepare all things
             # related to writing a transaction.
             transaction = self.m_transaction_builder.prepare_transaction(
-                node, submitter, [doi_obj], input_path=input_file,
+                node, submitter, dois_obj, input_path=input_file,
                 output_content=doi_label
             )
 

--- a/pds_doi_service/core/actions/release.py
+++ b/pds_doi_service/core/actions/release.py
@@ -24,7 +24,7 @@ from pds_doi_service.core.input.exceptions import (UnknownNodeException,
                                                    IllegalDOIActionException,
                                                    CriticalDOIException,
                                                    collect_exception_classes_and_messages,
-                                                   raise_warn_exceptions)
+                                                   raise_or_warn_exceptions)
 from pds_doi_service.core.input.osti_input_validator import OSTIInputValidator
 from pds_doi_service.core.input.node_util import NodeUtil
 from pds_doi_service.core.outputs.osti import DOIOutputOsti
@@ -155,10 +155,12 @@ class DOICoreActionRelease(DOICoreAction):
                     err, exception_classes, exception_messages
                 )
 
-        # If there is at least one exception caught, raise a WarningDOIException
-        # with all the messages, provided the force flag is not set
-        if len(exception_classes) > 0 and not self._force:
-            raise_warn_exceptions(exception_classes, exception_messages)
+        # If there is at least one exception caught, either raise a
+        # WarningDOIException or log a warning with all the messages,
+        # depending on the the state of the force flag
+        if len(exception_classes) > 0:
+            raise_or_warn_exceptions(exception_classes, exception_messages,
+                                     log=self._force)
 
         return dois
 

--- a/pds_doi_service/core/actions/release.py
+++ b/pds_doi_service/core/actions/release.py
@@ -95,7 +95,7 @@ class DOICoreActionRelease(DOICoreAction):
 
     def _parse_input(self, input_file):
         if input_file.endswith('.xml'):
-            with open(input_file, mode='rb') as f:
+            with open(input_file, mode='r') as f:
                 o_doi_label = f.read()
         else:
             msg = f"Input file {input_file} type not supported yet."

--- a/pds_doi_service/core/actions/reserve.py
+++ b/pds_doi_service/core/actions/reserve.py
@@ -28,7 +28,7 @@ from pds_doi_service.core.input.exceptions import (CriticalDOIException,
                                                    UnexpectedDOIActionException,
                                                    UnknownNodeException,
                                                    collect_exception_classes_and_messages,
-                                                   raise_warn_exceptions)
+                                                   raise_or_warn_exceptions)
 from pds_doi_service.core.input.input_util import DOIInputUtil
 from pds_doi_service.core.input.node_util import NodeUtil
 from pds_doi_service.core.input.osti_input_validator import OSTIInputValidator
@@ -231,10 +231,12 @@ class DOICoreActionReserve(DOICoreAction):
                     err, exception_classes, exception_messages
                 )
 
-        # If there is at least one exception caught, raise a WarningDOIException
-        # with all the messages, provided the force flag is not set
-        if len(exception_classes) > 0 and not self._force:
-            raise_warn_exceptions(exception_classes, exception_messages)
+        # If there is at least one exception caught, either raise a
+        # WarningDOIException or log a warning with all the messages,
+        # depending on the the state of the force flag
+        if len(exception_classes) > 0:
+            raise_or_warn_exceptions(exception_classes, exception_messages,
+                                     log=self._force)
 
         return dois
 

--- a/pds_doi_service/core/actions/reserve.py
+++ b/pds_doi_service/core/actions/reserve.py
@@ -14,10 +14,6 @@ Contains the definition for the Reserve action of the Core PDS DOI Service.
 """
 
 from datetime import datetime
-import os
-import requests
-
-from lxml import etree
 
 from pds_doi_service.core.actions.action import DOICoreAction
 from pds_doi_service.core.entities.doi import DoiStatus
@@ -32,7 +28,6 @@ from pds_doi_service.core.input.exceptions import (CriticalDOIException,
 from pds_doi_service.core.input.input_util import DOIInputUtil
 from pds_doi_service.core.input.node_util import NodeUtil
 from pds_doi_service.core.input.osti_input_validator import OSTIInputValidator
-from pds_doi_service.core.input.pds4_util import DOIPDS4LabelUtil
 from pds_doi_service.core.outputs.osti import DOIOutputOsti
 from pds_doi_service.core.outputs.osti_web_client import DOIOstiWebClient
 from pds_doi_service.core.util.doi_validator import DOIValidator
@@ -94,103 +89,8 @@ class DOICoreActionReserve(DOICoreAction):
                  "of 'reserved_not_submitted'."
         )
 
-    def _read_from_path(self, path):
-        if os.path.isfile(path):
-            if path.endswith('.xml'):
-                return self._read_from_local_pdf4(path)
-            elif path.endswith('.xlsx') or path.endswith('.xls'):
-                return self._read_from_local_xlsx(path)
-            elif path.endswith('.csv'):
-                return self._read_from_local_csv(path)
-            else:
-                logger.info(f'file {path} not supported')
-        else:
-            dois = []
-
-            for sub_path in os.listdir(path):
-                dois.extend(self._read_from_path(os.path.join(path, sub_path)))
-
-            return dois
-
-    def _read_from_remote_pds4(self, url):
-        try:
-            response = requests.get(url)
-            xml_tree = etree.fromstring(response.content)
-            label_util = DOIPDS4LabelUtil(
-                landing_page_template=self._config.get('LANDING_PAGES', 'url')
-            )
-            doi = label_util.get_doi_fields_from_pds4(xml_tree)
-
-            return [doi]
-        except OSError as err:
-            msg = f'Error reading file {url}, reason: {str(err)}'
-            logger.error(msg)
-            raise InputFormatException(msg)
-
-    def _read_from_local_pdf4(self, path):
-        # parse input
-        try:
-            xml_tree = etree.parse(path)
-            label_util =  DOIPDS4LabelUtil(
-                landing_page_template=self._config.get('LANDING_PAGES', 'url')
-            )
-            doi = label_util.get_doi_fields_from_pds4(xml_tree)
-
-            return [doi]
-        except OSError as err:
-            msg = f'Error reading file {path}, reason: {str(err)}'
-            logger.error(msg)
-            raise InputFormatException(msg)
-
-    def _read_from_local_xlsx(self, path):
-        """Processes a Reserve action based on a file with an .xlsx ending."""
-        try:
-            dois = DOIInputUtil().parse_sxls_file(path)
-
-            # Do a sanity check on content of dict_condition_data.
-            if len(dois) == 0:
-                raise InputFormatException(
-                    "Length of dict_condition_data['dois'] is zero, target_url " + path
-                )
-
-            return dois
-        except InputFormatException as err:
-            logger.error(err)
-            exit(1)
-        except OSError as err:
-            msg = f'Error reading file {path}, reason: {str(err)}'
-            logger.error(msg)
-            raise InputFormatException(msg)
-
-    def _read_from_local_csv(self, path):
-        """Processes a Reserve action based on a file with a .csv ending."""
-        try:
-            dois = DOIInputUtil().parse_csv_file(path)
-
-            # Do a sanity check on content of dict_condition_data.
-            if len(dois) == 0:
-                raise InputFormatException(
-                    "Length of dict_condition_data['dois'] is zero, target_url " + path
-                )
-
-            return dois
-        except InputFormatException as err:
-            logger.error(err)
-            exit(1)
-        except OSError as err:
-            msg = f'Error reading file {path}, reason: {str(err)}'
-            logger.error(msg)
-            raise InputFormatException(msg)
-
     def _parse_input(self, input_file):
-        # Check for existence first to return the message the 'behave' testing
-        # expects.
-        if input_file.startswith('http'):
-            return self._read_from_remote_pds4(input_file)
-        elif os.path.exists(input_file):
-            return self._read_from_path(input_file)
-        else:
-            raise InputFormatException(f"Error reading file {input_file}")
+        return DOIInputUtil().parse_dois_from_input_file(input_file)
 
     def complete_and_validate_dois(self, dois, contributor, publisher, dry_run):
         exception_classes = []
@@ -311,6 +211,7 @@ class DOICoreActionReserve(DOICoreAction):
 
             logger.debug(f"reserve_response {o_doi_label}")
             logger.debug(f"_input,self,_dry_run {self._input, self._dry_run}")
+
             return o_doi_label
         # Convert other errors into a CriticalDOIException to report back
         except (UnknownNodeException, InputFormatException) as err:

--- a/pds_doi_service/core/actions/test/release_test.py
+++ b/pds_doi_service/core/actions/test/release_test.py
@@ -73,9 +73,7 @@ class ReleaseActionTestCase(unittest.TestCase):
 
         o_doi_label = self._action.run(**release_args)
 
-        dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(
-            bytes(o_doi_label, encoding='utf-8')
-        )
+        dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(o_doi_label)
 
         # Should get three DOI's back that have all been marked as ready for review
         self.assertEqual(len(dois), 3)
@@ -97,9 +95,7 @@ class ReleaseActionTestCase(unittest.TestCase):
 
         o_doi_label = self._action.run(**release_args)
 
-        dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(
-            bytes(o_doi_label, encoding='utf-8')
-        )
+        dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(o_doi_label)
 
         # Should get three DOI's back that have all been marked as pending
         # registration
@@ -119,9 +115,7 @@ class ReleaseActionTestCase(unittest.TestCase):
 
         o_doi_label = self._action.run(**release_args)
 
-        dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(
-            bytes(o_doi_label, encoding='utf-8')
-        )
+        dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(o_doi_label)
 
         # Should get one DOI back with status 'review'
         self.assertEqual(len(dois), 1)
@@ -143,9 +137,7 @@ class ReleaseActionTestCase(unittest.TestCase):
 
         o_doi_label = self._action.run(**release_args)
 
-        dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(
-            bytes(o_doi_label, encoding='utf-8')
-        )
+        dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(o_doi_label)
 
         # Should get one DOI back with status 'pending'
         self.assertEqual(len(dois), 1)
@@ -168,9 +160,7 @@ class ReleaseActionTestCase(unittest.TestCase):
 
         o_doi_label = self._action.run(**release_args)
 
-        dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(
-            bytes(o_doi_label, encoding='utf-8')
-        )
+        dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(o_doi_label)
 
         # Should get one DOI back with status 'review'
         self.assertEqual(len(dois), 1)
@@ -192,9 +182,7 @@ class ReleaseActionTestCase(unittest.TestCase):
 
         o_doi_label = self._action.run(**release_args)
 
-        dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(
-            bytes(o_doi_label, encoding='utf-8')
-        )
+        dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(o_doi_label)
 
         # Should get one DOI back with status 'pending'
         self.assertEqual(len(dois), 1)

--- a/pds_doi_service/core/actions/test/release_test.py
+++ b/pds_doi_service/core/actions/test/release_test.py
@@ -75,9 +75,9 @@ class ReleaseActionTestCase(unittest.TestCase):
 
         dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(o_doi_label)
 
-        # Should get three DOI's back that have all been marked as ready for review
-        self.assertEqual(len(dois), 3)
-        self.assertTrue(all([doi.status == DoiStatus.Review for doi in dois]))
+        # Should get one DOI back that has been marked as ready for review
+        self.assertEqual(len(dois), 1)
+        self.assertTrue(dois[0].status == DoiStatus.Review)
 
     @patch.object(
         pds_doi_service.core.outputs.osti_web_client.DOIOstiWebClient,
@@ -97,10 +97,9 @@ class ReleaseActionTestCase(unittest.TestCase):
 
         dois, _ = DOIOstiWebParser().response_get_parse_osti_xml(o_doi_label)
 
-        # Should get three DOI's back that have all been marked as pending
-        # registration
-        self.assertEqual(len(dois), 3)
-        self.assertTrue(all([doi.status == DoiStatus.Pending for doi in dois]))
+        # Should get one DOI back that has been marked as pending registration
+        self.assertEqual(len(dois), 1)
+        self.assertTrue(dois[0].status == DoiStatus.Pending)
 
     def test_draft_release_to_review(self):
         """Test release to review status with a draft DOI entry"""

--- a/pds_doi_service/core/input/exceptions.py
+++ b/pds_doi_service/core/input/exceptions.py
@@ -15,7 +15,7 @@ Contains exception classes and functions for collecting and managing exceptions.
 
 from pds_doi_service.core.util.general_util import get_logger
 
-logger = get_logger('pds_doi_core.input.exceptions')
+logger = get_logger('pds_doi_service.core.input.exceptions')
 
 
 class InputFormatException(Exception):
@@ -117,10 +117,10 @@ def collect_exception_classes_and_messages(single_exception,
     return io_exception_classes, io_exception_messages
 
 
-def raise_warn_exceptions(exception_classes, exception_messages):
+def raise_or_warn_exceptions(exception_classes, exception_messages, log=False):
     """
-    Raise a WarningDOIException that rolls up all the of the provided
-    exception class names and messages.
+    Raise a WarningDOIException or log a warning message that rolls up all the
+    of the provided exception class names and messages.
 
     Parameters
     ----------
@@ -128,6 +128,9 @@ def raise_warn_exceptions(exception_classes, exception_messages):
         The list of exception class names to include in the WarningDOIException
     exception_messages : list of str
         The list of exception messages to include in the WarningDOIException
+    log : bool
+        If True, log the combined message as a warning, otherwise raise
+        A WarningDOIException
 
     Raises
     ------
@@ -149,4 +152,7 @@ def raise_warn_exceptions(exception_classes, exception_messages):
                                 + ', ' + exception_classes[ii]
                                 + ':' + exception_messages[ii])
 
-    raise WarningDOIException(message_to_raise)
+    if log:
+        logger.warning(message_to_raise)
+    else:
+        raise WarningDOIException(message_to_raise)

--- a/pds_doi_service/core/input/input_util.py
+++ b/pds_doi_service/core/input/input_util.py
@@ -13,12 +13,22 @@ input_util.py
 Contains classes for working with input label files, be they local or remote.
 """
 
-import pandas as pd
+import os
+import urllib.parse
+import tempfile
+from os.path import basename
 from datetime import datetime
 
-from pds_doi_service.core.entities.doi import Doi, ProductType
+import pandas as pd
+import requests
+from lxml import etree
+
+from pds_doi_service.core.entities.doi import Doi, DoiStatus, ProductType
 from pds_doi_service.core.input.exceptions import InputFormatException
-from pds_doi_service.core.outputs.output_util import DOIOutputUtil
+from pds_doi_service.core.input.pds4_util import DOIPDS4LabelUtil
+from pds_doi_service.core.outputs.osti_web_parser import DOIOstiWebParser
+from pds_doi_service.core.util.config_parser import DOIConfigUtil
+from pds_doi_service.core.util.doi_validator import DOIValidator
 from pds_doi_service.core.util.general_util import get_logger
 
 # Get the common logger
@@ -26,18 +36,92 @@ logger = get_logger('pds_doi_service.core.input.input_util')
 
 
 class DOIInputUtil:
-    m_doi_output_util = DOIOutputUtil()
 
     EXPECTED_NUM_COLUMNS = 7
     """Expected number of columns in an input CSV file."""
 
     MANDATORY_COLUMNS = ['status', 'title', 'publication_date',
                          'product_type_specific', 'author_last_name',
-                         'author_first_name','related_resource']
+                         'author_first_name', 'related_resource']
     """The names of the expected columns within a CSV file."""
 
     EXPECTED_PUBLICATION_DATE_LEN = 10
     """Expected minimum length of a parsed publication date."""
+
+    DEFAULT_VALID_EXTENSIONS = ['.xml', '.csv', '.xlsx', '.xls']
+    """The default list of valid input file extensions this module can read."""
+
+    def __init__(self, valid_extensions=None):
+        """
+        Creates a new DOIInputUtil instance.
+
+        Parameters
+        ----------
+        valid_extensions : iterable, optional
+            A listing of the extensions this input util instance should
+            support. Must be a subset of the default extensions supported
+            by this module. If not provided, all the default extensions are
+            allowed.
+
+        Raises
+        ------
+        ValueError
+            If one or more unsupported extensions is provided.
+
+        """
+        self._config = DOIConfigUtil().get_config()
+        self._label_util = DOIPDS4LabelUtil(
+            landing_page_template=self._config.get('LANDING_PAGES', 'url')
+        )
+        self._valid_extensions = valid_extensions or self.DEFAULT_VALID_EXTENSIONS
+
+        if not isinstance(self._valid_extensions, (list, tuple, set)):
+            self._valid_extensions = [self._valid_extensions]
+
+        # Set up the mapping of supported extensions to the corresponding read
+        # function pointers
+        self._parser_map = {
+            '.xml': self.parse_xml_file,
+            '.xls': self.parse_sxls_file,
+            '.xlsx': self.parse_sxls_file,
+            '.csv': self.parse_csv_file
+        }
+
+        if not all([extension in self._parser_map
+                    for extension in self._valid_extensions]):
+            raise ValueError('One or more the provided extensions are not '
+                             'supported by the DOIInputUtil class.')
+
+    def parse_xml_file(self, xml_path):
+        """
+        Parses DOIs from a file with an .xml extension. The file is expected
+        to conform either to the PDS4 label or OSTI output label schema.
+
+        """
+        dois = []
+
+        # First read the contents of the file
+        with open(xml_path, 'r') as infile:
+            xml_contents = infile.read()
+
+        # Next, try validating xml against the OSTI schema to determine
+        # the format
+        if DOIValidator().validate_against_xsd(
+                xml_contents, use_alternate_validation_method=False):
+            dois, _ = DOIOstiWebParser.response_get_parse_osti_xml(xml_contents)
+        # Finally, try parsing as a PDS4 label
+        else:
+            try:
+                xml_tree = etree.fromstring(xml_contents.encode())
+
+                dois.append(self._label_util.get_doi_fields_from_pds4(xml_tree))
+            except Exception:
+                raise InputFormatException(
+                    f'Could not parse xml file {xml_path} as either a PDS4 label '
+                    f'or OSTI output label.'
+                )
+
+        return dois
 
     def parse_sxls_file(self, i_filepath):
         """
@@ -89,7 +173,6 @@ class DOIInputUtil:
         Given all rows in input file, parse each row and return the aggregated
         XML of all records in OSTI format.
         """
-
         doi_records = []
 
         for index, row in xl_sheet.iterrows():
@@ -118,7 +201,8 @@ class DOIInputUtil:
                     f"[{row['publication_date']}]"
                 )
 
-            doi = Doi(title=row['title'],
+            doi = Doi(status=DoiStatus(row['status'].lower()),
+                      title=row['title'],
                       publication_date=publication_date_value,
                       product_type=ProductType.Collection,
                       product_type_specific=row['product_type_specific'],
@@ -131,15 +215,13 @@ class DOIInputUtil:
 
         return doi_records
 
-    def parse_csv_file(self, i_filepath):
+    def parse_csv_file(self, csv_filepath):
         """
         Receives a URI containing CSV format and create one external file per
         row to output directory.
         """
-        logger.info("i_filepath " + i_filepath)
-
         # Read the CSV file into memory.
-        csv_sheet = pd.read_csv(i_filepath)
+        csv_sheet = pd.read_csv(csv_filepath)
         num_cols = len(csv_sheet.columns)
         num_rows = len(csv_sheet.index)
 
@@ -153,11 +235,154 @@ class DOIInputUtil:
                    f"CSV file, but only found {num_cols} columns.")
 
             logger.error(msg)
-            logger.error("i_filepath " + i_filepath)
+            logger.error("csv_filepath " + csv_filepath)
             logger.error("data columns " + str(list(csv_sheet.columns)))
             raise InputFormatException(msg)
         else:
             dois = self._parse_rows_to_doi_meta(csv_sheet)
             logger.info("FILE_WRITE_SUMMARY: num_rows " + str(num_rows))
+
+        return dois
+
+    def _read_from_path(self, path):
+        """
+        Parses Doi's from the file or files referenced by the provided path.
+        If the path points to a single file, only that file is parsed. Otherwise,
+        directories are walked for any files contained within. Any files with
+        unsupported extensions are ignored.
+
+        Parameters
+        ----------
+        path : str
+            Path to the location to read. May be a single file or directory.
+
+        Returns
+        -------
+        InputFormatException
+            If an error is encountered while reading a local file.
+
+        """
+        dois = []
+
+        if os.path.isfile(path):
+            logger.info(f'Reading local file path {path}')
+
+            extension = os.path.splitext(path)[-1]
+
+            if extension in self._valid_extensions:
+                # Select the appropriate read function based on the extension
+                read_function = self._parser_map[extension]
+
+                try:
+                    dois = read_function(path)
+                except OSError as err:
+                    msg = f'Error reading file {path}, reason: {str(err)}'
+
+                    logger.error(msg)
+                    raise InputFormatException(msg)
+            else:
+                logger.info(f'File {path} has unsupported extension, ignoring')
+        else:
+            logger.info(f'Reading files within directory {path}')
+
+            for sub_path in os.listdir(path):
+                dois.extend(self._read_from_path(os.path.join(path, sub_path)))
+
+        return dois
+
+    def _read_from_remote(self, input_url):
+        """
+        Reads a remote file from the provided URL into a local temporary file,
+        then parses and returns any Dois from it. The local temp file is
+        deleted once this function returns.
+
+        Parameters
+        ----------
+        input_url : str
+            The URL to the file to download locally.
+
+        Returns
+        -------
+        dois : list of Doi
+            The Doi's parsed from the remote file.
+
+        Raises
+        ------
+        InputFormatException
+            If the URL points to a file with an unsupported extension.
+
+        """
+        parsed_url = urllib.parse.urlparse(input_url)
+
+        # Check for valid extension before attempting to read from remote
+        extension = os.path.splitext(parsed_url.path)[-1]
+
+        if extension not in self._valid_extensions:
+            raise InputFormatException(
+                f'File extension type "{extension}" is not supported for this, '
+                f'operation, must be one of {",".join(self._valid_extensions)}'
+            )
+
+        response = requests.get(input_url)
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as http_err:
+            raise InputFormatException(
+                f'Could not read remote file {input_url}, reason: {str(http_err)}'
+            )
+
+        with tempfile.NamedTemporaryFile(suffix=basename(parsed_url.path)) as temp_file:
+            temp_file.write(response.content)
+            temp_file.seek(0)
+
+            return self._read_from_path(temp_file.name)
+
+    def parse_dois_from_input_file(self, input_file):
+        """
+        Parses one or more Doi objects from the provided input file location.
+        The location may be a path to a local file or directory, or a remote
+        URL to the desired file.
+
+        Parameters
+        ----------
+        input_file : str
+            The location of the input to parse Doi's from. If a local directory,
+            the location will be walked for input files. If a remote URL,
+            the file will be read into a local temporary file, then processed
+            like a local path.
+
+        Returns
+        -------
+        dois : list of Doi
+            The list of Doi objects parsed from the input location.
+
+        Raises
+        ------
+        InputFormatException
+            If the input location does not correspond to a URL (starting with
+            http), or a local path, or if no Doi objects can be parsed from
+            the file (because it is an unsupported exception).
+
+        """
+        # See if we were handed a URL
+        if input_file.startswith('http'):
+            dois = self._read_from_remote(input_file)
+        # Otherwise see if its a local file
+        elif os.path.exists(input_file):
+            dois = self._read_from_path(input_file)
+        else:
+            raise InputFormatException(
+                f"Error reading file {input_file}, path does not correspond to "
+                f"a remote URL or a local file path."
+            )
+
+        # Make sure we got back at least one Doi
+        if not dois:
+            raise InputFormatException(
+                f"Unable to parse DOI's from input location {input_file}\n"
+                f"Please ensure the input is of the following type(s): "
+                f"{', '.join(self._valid_extensions)}"
+            )
 
         return dois

--- a/pds_doi_service/core/input/input_util.py
+++ b/pds_doi_service/core/input/input_util.py
@@ -1,110 +1,163 @@
+#
+#  Copyright 2021, by the California Institute of Technology.  ALL RIGHTS
+#  RESERVED. United States Government Sponsorship acknowledged. Any commercial
+#  use must be negotiated with the Office of Technology Transfer at the
+#  California Institute of Technology.
+#
+
+"""
+=============
+input_util.py
+=============
+
+Contains classes for working with input label files, be they local or remote.
+"""
+
 import pandas as pd
 from datetime import datetime
 
+from pds_doi_service.core.entities.doi import Doi, ProductType
+from pds_doi_service.core.input.exceptions import InputFormatException
 from pds_doi_service.core.outputs.output_util import DOIOutputUtil
 from pds_doi_service.core.util.general_util import get_logger
-from pds_doi_service.core.input.exceptions import InputFormatException
-from pds_doi_service.core.entities.doi import Doi
 
-# Get the common logger and set the level for this file if desire.
-
-logger = get_logger('pds_doi_core.input.input_util')
+# Get the common logger
+logger = get_logger('pds_doi_service.core.input.input_util')
 
 
 class DOIInputUtil:
     m_doi_output_util = DOIOutputUtil()
 
-    m_EXPECTED_NUM_COLUMNS = 7
-    MANDATORY_COLUMNS = ['status', 'title', 'publication_date','product_type_specific','author_last_name','author_first_name','related_resource']
+    EXPECTED_NUM_COLUMNS = 7
+    """Expected number of columns in an input CSV file."""
+
+    MANDATORY_COLUMNS = ['status', 'title', 'publication_date',
+                         'product_type_specific', 'author_last_name',
+                         'author_first_name','related_resource']
+    """The names of the expected columns within a CSV file."""
+
+    EXPECTED_PUBLICATION_DATE_LEN = 10
+    """Expected minimum length of a parsed publication date."""
 
     def parse_sxls_file(self, i_filepath):
-        """Function receives a URI containing SXLS format and create one external file per row to output directory."""
-
-        logger.info("i_filepath" + " " + i_filepath)
+        """
+        Receives a URI containing SXLS format and writes one external file per
+        row to an output directory.
+        """
+        logger.info("i_filepath " + i_filepath)
 
         xl_wb = pd.ExcelFile(i_filepath, engine='openpyxl')
-        actual_sheet_name = xl_wb.sheet_names[0]  # We only want the first sheet.
-        xl_sheet = pd.read_excel(i_filepath, actual_sheet_name, converters={'publication_date': str,
-                                                                       'publication_date (yyyy-mm-dd)': str})
+
+        # We only want the first sheet.
+        actual_sheet_name = xl_wb.sheet_names[0]
+        xl_sheet = pd.read_excel(
+            i_filepath, actual_sheet_name,
+            converters={'publication_date': str,
+                        'publication_date (yyyy-mm-dd)': str}
+        )
+
         num_cols = len(xl_sheet.columns)
         num_rows = len(xl_sheet.index)
 
-        logger.info("num_cols" + " " + str(num_cols))
-        logger.info("num_rows" + " " + str(num_rows))
-        logger.debug("data columns " + " " + str(list(xl_sheet.columns)))
+        logger.info("num_cols " + str(num_cols))
+        logger.info("num_rows " + str(num_rows))
+        logger.debug("data columns " + str(list(xl_sheet.columns)))
 
-        # rename columns in a more simple way
-        xl_sheet = xl_sheet.rename(columns={'publication_date (yyyy-mm-dd)': 'publication_date',
-                                            'product_type_specific\n(PDS4 Bundle | PDS4 Collection | PDS4 Document)': 'product_type_specific',
-                                            'related_resource\nLIDVID': 'related_resource'})
+        # rename columns in a simpler way
+        xl_sheet = xl_sheet.rename(
+            columns={
+                'publication_date (yyyy-mm-dd)': 'publication_date',
+                'product_type_specific\n(PDS4 Bundle | PDS4 Collection | PDS4 Document)': 'product_type_specific',
+                'related_resource\nLIDVID': 'related_resource'
+            }
+        )
 
-        if num_cols < self.m_EXPECTED_NUM_COLUMNS:
-            msg = f"expecting {self.m_EXPECTED_NUM_COLUMNS} columns in XLS file has {num_cols} columns."
+        if num_cols < self.EXPECTED_NUM_COLUMNS:
+            msg = (f"Expected {self.EXPECTED_NUM_COLUMNS} columns in the "
+                   f"provided XLS file, but only found {num_cols} columns.")
+
             logger.error(msg)
             raise InputFormatException(msg)
         else:
             dois = self._parse_rows_to_doi_meta(xl_sheet)
-            logger.info("FILE_WRITE_SUMMARY:num_rows" + " " + str(num_rows))
+            logger.info("FILE_WRITE_SUMMARY: num_rows " + str(num_rows))
 
         return dois
 
     def _parse_rows_to_doi_meta(self, xl_sheet):
-        """Given all rows in input file, parse each row and return the aggregated XML of all records in OSTI format"""
+        """
+        Given all rows in input file, parse each row and return the aggregated
+        XML of all records in OSTI format.
+        """
 
         doi_records = []
 
         for index, row in xl_sheet.iterrows():
             logger.debug(f"row {row}")
-            # It is possible that the length of row['publication_date'] is more than needed, we only need to get the first 10 characters
-            #   '2020-08-01' from '2020-08-01 00:00:00' 
-            if len(row['publication_date']) >= 10:
-                # It is possible that the format provided is not expected, put try/except clause to catch that.
+            # It is possible that the length of row['publication_date'] is more
+            # than needed, we only need to get the first 10 characters
+            #   '2020-08-01' from '2020-08-01 00:00:00'
+            if len(row['publication_date']) >= self.EXPECTED_PUBLICATION_DATE_LEN:
+                # It is possible that the format provided is not expected,
+                # put a try/except clause to catch that.
                 try:
-                    publication_date_value =  datetime.strptime(row['publication_date'][0:10], '%Y-%m-%d')
+                    publication_date_value = datetime.strptime(
+                        row['publication_date'][:self.EXPECTED_PUBLICATION_DATE_LEN],
+                        '%Y-%m-%d'
+                    )
                 except Exception:
-                    logger.error("Expecting publication_date [" + row['publication_date'] + "] with format YYYY-mm-dd")
-                    raise InputFormatException("Expecting publication_date [" + row['publication_date'] + "] with format YYYY-mm-dd")
+                    msg = (f"Expecting publication_date "
+                           f"[{row['publication_date']}] with format YYYY-mm-dd")
+
+                    logger.error(msg)
+                    raise InputFormatException(msg)
             else:
-                raise InputFormatException("Expecting publication_date to be at least 10 characters: [" + row['publication_date'] + "]")
+                raise InputFormatException(
+                    f"Expecting publication_date to be at least "
+                    f"{self.EXPECTED_PUBLICATION_DATE_LEN} characters: "
+                    f"[{row['publication_date']}]"
+                )
 
             doi = Doi(title=row['title'],
                       publication_date=publication_date_value,
-                      product_type='Collection',
+                      product_type=ProductType.Collection,
                       product_type_specific=row['product_type_specific'],
                       related_identifier=row['related_resource'],
                       authors=[{'first_name': row['author_first_name'],
                                 'last_name': row['author_last_name']}])
+
             logger.debug(f'getting doi metadata {doi.__dict__}')
             doi_records.append(doi)
 
         return doi_records
 
     def parse_csv_file(self, i_filepath):
-        """Function receives a URI containing CSV format and create one external file per row to output directory."""
-
-        logger.info("i_filepath" + " " + i_filepath)
+        """
+        Receives a URI containing CSV format and create one external file per
+        row to output directory.
+        """
+        logger.info("i_filepath " + i_filepath)
 
         # Read the CSV file into memory.
-
         csv_sheet = pd.read_csv(i_filepath)
         num_cols = len(csv_sheet.columns)
         num_rows = len(csv_sheet.index)
 
-        logger.debug("xl_sheet.head() " + " " + str(csv_sheet.head()))
-        logger.info("num_cols" + " " + str(num_cols))
-        logger.info("num_rows" + " " + str(num_rows))
-        logger.debug("data columns" + str(list(csv_sheet.columns)))
+        logger.debug("csv_sheet.head() " + str(csv_sheet.head()))
+        logger.info("num_cols " + str(num_cols))
+        logger.info("num_rows " + str(num_rows))
+        logger.debug("data columns " + str(list(csv_sheet.columns)))
 
-        if num_cols < self.m_EXPECTED_NUM_COLUMNS:
-            logger.error(
-                "expecting" + " " + str(self.m_EXPECTED_NUM_COLUMNS) + " columns in CSV file has %i columns." % (
-                    num_cols))
-            logger.error("i_filepath" + " " + i_filepath)
-            logger.error("data columns " + " " + str(list(csv_sheet.columns)))
-            raise InputFormatException("columns " + " " + str(list(csv_sheet.columns)))
+        if num_cols < self.EXPECTED_NUM_COLUMNS:
+            msg = (f"Expecting {self.EXPECTED_NUM_COLUMNS} columns in the provided "
+                   f"CSV file, but only found {num_cols} columns.")
+
+            logger.error(msg)
+            logger.error("i_filepath " + i_filepath)
+            logger.error("data columns " + str(list(csv_sheet.columns)))
+            raise InputFormatException(msg)
         else:
             dois = self._parse_rows_to_doi_meta(csv_sheet)
-
-            logger.info("FILE_WRITE_SUMMARY:num_rows" + " " + str(num_rows))
+            logger.info("FILE_WRITE_SUMMARY: num_rows " + str(num_rows))
 
         return dois

--- a/pds_doi_service/core/input/pds4_util.py
+++ b/pds_doi_service/core/input/pds4_util.py
@@ -17,7 +17,7 @@ import requests
 from datetime import datetime
 from enum import Enum
 
-from pds_doi_service.core.entities.doi import Doi, ProductType
+from pds_doi_service.core.entities.doi import Doi, DoiStatus, ProductType
 from pds_doi_service.core.input.exceptions import InputFormatException
 from pds_doi_service.core.util.general_util import get_logger
 from pds_doi_service.core.util.keyword_tokenizer import KeywordTokenizer
@@ -242,7 +242,8 @@ class DOIPDS4LabelUtil:
             if len(doi_prefix_suffix) == 2:
                 osti_id = doi_prefix_suffix[1]
 
-        doi = Doi(title=pds4_fields['title'],
+        doi = Doi(status=DoiStatus.Unknown,
+                  title=pds4_fields['title'],
                   description=pds4_fields['description'],
                   publication_date=self.get_publication_date(pds4_fields),
                   product_type=product_type,

--- a/pds_doi_service/core/input/test/input_util_test.py
+++ b/pds_doi_service/core/input/test/input_util_test.py
@@ -1,28 +1,154 @@
+#!/usr/bin/env python
+
+import datetime
 import os
 import unittest
+from os.path import abspath, dirname, join
+
+from pds_doi_service.core.entities.doi import Doi, DoiStatus, ProductType
 from pds_doi_service.core.input.input_util import DOIInputUtil
-from pds_doi_service.core.util.general_util import get_logger
+from pds_doi_service.core.input.exceptions import InputFormatException
 
 
-logger = get_logger()
+class InputUtilTestCase(unittest.TestCase):
 
+    def setUp(self):
+        self.test_dir = abspath(dirname(__file__))
+        self.input_dir = abspath(
+            join(self.test_dir, os.pardir, os.pardir, os.pardir, os.pardir, 'input')
+        )
 
-class MyTestCase(unittest.TestCase):
+    def test_parse_dois_from_input_file(self):
+        """Test the DOIInputUtil.parse_dois_from_input_file() method"""
+        doi_input_util = DOIInputUtil(valid_extensions='.xml')
+
+        # Test with local file
+        i_filepath = join(self.input_dir, 'bundle_in_with_contributors.xml')
+        dois = doi_input_util.parse_dois_from_input_file(i_filepath)
+
+        self.assertEqual(len(dois), 1)
+
+        # Test with remote file
+        i_filepath = 'https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/bundle.xml'
+        dois = doi_input_util.parse_dois_from_input_file(i_filepath)
+
+        self.assertEqual(len(dois), 1)
+
+        # Test with local directory
+        i_filepath = join(self.input_dir, 'draft_dir_two_files')
+        dois = doi_input_util.parse_dois_from_input_file(i_filepath)
+
+        self.assertEqual(len(dois), 2)
+
+        # Test with invalid local file path (does not exist)
+        i_filepath = '/dev/null/file/does/not/exist'
+        with self.assertRaises(InputFormatException):
+            doi_input_util.parse_dois_from_input_file(i_filepath)
+
+        # Test with invalid remote file path (does not exist)
+        i_filepath = 'https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/fake_bundle.xml'
+        with self.assertRaises(InputFormatException):
+            doi_input_util.parse_dois_from_input_file(i_filepath)
+
+        # Test local file with invalid extension
+        i_filepath = join(self.input_dir, 'DOI_Reserved_GEO_200318.xlsx')
+        with self.assertRaises(InputFormatException):
+            doi_input_util.parse_dois_from_input_file(i_filepath)
+
+        # Test remote file with invalid extension
+        doi_input_util = DOIInputUtil(valid_extensions='.csv')
+        i_filepath = 'https://pds-imaging.jpl.nasa.gov/data/nsyt/insight_cameras/bundle.xml'
+        with self.assertRaises(InputFormatException):
+            doi_input_util.parse_dois_from_input_file(i_filepath)
+
     def test_read_xls(self):
-
+        """Test the DOIInputUtil.parse_sxls_file() method"""
         doi_input_util = DOIInputUtil()
 
-        i_filepath = os.path.join(os.getcwd(), 'input', 'DOI_Reserved_GEO_200318.xlsx')
-        o_num_files_created = doi_input_util.parse_sxls_file(i_filepath)
-        logger.info(f"o_num_files_created {o_num_files_created}")
+        # Test single entry spreadsheet
+        i_filepath = join(self.input_dir, 'DOI_Reserved_GEO_200318.xlsx')
+        dois = doi_input_util.parse_sxls_file(i_filepath)
+
+        self.assertEqual(len(dois), 1)
+
+        doi = dois[0]
+
+        self.assertIsInstance(doi, Doi)
+        self.assertEqual(doi.title, 'Laboratory Shocked Feldspars Bundle')
+        self.assertEqual(doi.status, DoiStatus.Reserved)
+        self.assertEqual(doi.related_identifier, 'urn:nasa:pds:lab_shocked_feldspars')
+        self.assertEqual(len(doi.authors), 1)
+        self.assertEqual(doi.product_type, ProductType.Collection)
+        self.assertEqual(doi.product_type_specific, 'PDS4 Collection')
+        self.assertIsInstance(doi.publication_date, datetime.datetime)
+
+        # Test multi entry spreadsheet
+        i_filepath = join(
+            self.input_dir,
+            'DOI_Reserved_GEO_200318_with_corrected_identifier.xlsx'
+        )
+
+        dois = doi_input_util.parse_sxls_file(i_filepath)
+
+        self.assertEqual(len(dois), 3)
+        self.assertTrue(all([doi.title.startswith('Laboratory Shocked Feldspars')
+                             for doi in dois]))
+        self.assertTrue(all([doi.status == DoiStatus.Reserved
+                             for doi in dois]))
+        self.assertTrue(all([doi.related_identifier.startswith('urn:nasa:pds:lab_shocked_feldspars')
+                             for doi in dois]))
+        self.assertTrue(all([len(doi.authors) == 1
+                             for doi in dois]))
+        self.assertTrue(all([doi.product_type == ProductType.Collection
+                             for doi in dois]))
+        self.assertTrue(all([isinstance(doi.publication_date, datetime.datetime)
+                             for doi in dois]))
+
 
     def test_read_csv(self):
-
+        """Test the DOIInputUtil.parse_csv_file() method"""
         doi_input_util = DOIInputUtil()
 
-        i_filepath = os.path.join(os.getcwd(), 'input','DOI_Reserved_GEO_200318.csv')
-        o_num_files_created = doi_input_util.parse_csv_file(i_filepath)
-        logger.info(f"o_num_files_created {o_num_files_created}")
+        i_filepath = join(self.input_dir, 'DOI_Reserved_GEO_200318.csv')
+        dois = doi_input_util.parse_csv_file(i_filepath)
+
+        self.assertEqual(len(dois), 3)
+        self.assertTrue(all([doi.title.startswith('Laboratory Shocked Feldspars')
+                             for doi in dois]))
+        self.assertTrue(all([doi.status == DoiStatus.Reserved
+                             for doi in dois]))
+        self.assertTrue(all([doi.related_identifier.startswith('urn:nasa:pds:lab_shocked_feldspars')
+                             for doi in dois]))
+        self.assertTrue(all([len(doi.authors) == 1
+                             for doi in dois]))
+        self.assertTrue(all([doi.product_type == ProductType.Collection
+                             for doi in dois]))
+        self.assertTrue(all([isinstance(doi.publication_date, datetime.datetime)
+                             for doi in dois]))
+
+    def test_read_xml(self):
+        """Test the DOIInputUtil.parse_xml_file() method"""
+        doi_input_util = DOIInputUtil()
+
+        # Test with a PDS4 label
+        i_filepath = join(self.input_dir, 'bundle_in_with_contributors.xml')
+        dois = doi_input_util.parse_xml_file(i_filepath)
+
+        self.assertEqual(len(dois), 1)
+
+        doi = dois[0]
+
+        self.assertIsInstance(doi, Doi)
+
+        # Test with an OSTI output label
+        i_filepath = join(self.input_dir, 'DOI_Release_20200727_from_reserve.xml')
+        dois = doi_input_util.parse_xml_file(i_filepath)
+
+        self.assertEqual(len(dois), 1)
+
+        doi = dois[0]
+
+        self.assertIsInstance(doi, Doi)
 
 
 if __name__ == '__main__':

--- a/pds_doi_service/core/outputs/osti.py
+++ b/pds_doi_service/core/outputs/osti.py
@@ -49,7 +49,7 @@ class DOIOutputOsti:
 
             # Convert set of keywords back to a semi-colon delimited string
             if doi.keywords:
-                doi_fields['keywords'] = "; ".join(sorted(doi.keywords))
+                doi_fields['keywords'] = ";".join(sorted(doi.keywords))
 
             # publication_date is assigned to a Doi object as a datetime,
             # need to convert to a string for the OSTI label. Note that

--- a/pds_doi_service/core/outputs/osti_web_parser.py
+++ b/pds_doi_service/core/outputs/osti_web_parser.py
@@ -154,7 +154,7 @@ class DOIOstiWebParser:
 
             if optional_field_element and optional_field_element[0].text is not None:
                 if optional_field == 'keywords':
-                    io_doi.keywords = set(optional_field_element[0].text.split('; '))
+                    io_doi.keywords = set(optional_field_element[0].text.split(';'))
                     logger.debug(f"Adding optional field 'keywords': "
                                  f"{io_doi.keywords}")
                 elif optional_field == 'authors':
@@ -164,6 +164,8 @@ class DOIOstiWebParser:
                     logger.debug(f"Adding optional field 'authors': "
                                  f"{io_doi.authors}")
                 elif optional_field == 'contributors':
+                    # TODO: this should also parse the contributor (node long
+                    #  name) from the DataCurator contributor field
                     io_doi.editors = DOIOstiWebParser.parse_editor_names(
                         optional_field_element[0]
                     )
@@ -304,7 +306,7 @@ class DOIOstiWebParser:
         dois = []
         errors = []
 
-        doc = etree.fromstring(osti_response_text)
+        doc = etree.fromstring(osti_response_text.encode())
         my_root = doc.getroottree()
 
         # Trim down input to just fields we want.

--- a/pds_doi_service/core/util/doi_validator.py
+++ b/pds_doi_service/core/util/doi_validator.py
@@ -87,9 +87,9 @@ class DOIValidator:
                     logger.debug(f"site_url {doi.site_url} indeed exists")
             except (requests.exceptions.ConnectionError, Exception):
                 error_message = f"site_url {doi.site_url} not reachable"
+
                 # Although not being able to connect is an error, the message
                 # printed is a warning.
-                logger.warning(error_message)
                 raise SiteURLNotExistException(error_message)
 
     def _check_field_title_duplicate(self, doi: Doi):
@@ -129,7 +129,7 @@ class DOIValidator:
             msg = (f"The title '{doi.title}' has already been used for a DOI "
                    f"by lidvid(s): {lidvids}, status: {status}, doi: {','.join(dois)}. " 
                    "You must use a different title.")
-            logger.error(msg)
+
             raise DuplicatedTitleDOIException(msg)
 
     def _check_field_title_content(self, doi: Doi):
@@ -152,10 +152,11 @@ class DOIValidator:
                      f"doi.title: {doi.title}")
 
         if not product_type_specific_suffix.lower() in doi.title.lower():
-            msg = (f"DOI with lidvid '{doi.related_identifier}' title '{doi.title}' "
-                   f"does not contains product specific type suffix '{product_type_specific_suffix.lower()}'. "
+            msg = (f"DOI with lidvid '{doi.related_identifier}' title "
+                   f"'{doi.title}' does not contains product specific type "
+                   f"suffix '{product_type_specific_suffix.lower()}'. "
                    "Product specific type suffix should be in the title.")
-            logger.debug(msg)
+
             raise TitleDoesNotMatchProductTypeException(msg)
 
     def _check_field_lidvid_update(self, doi: Doi):
@@ -215,7 +216,8 @@ class DOIValidator:
             doi_str = row[columns.index('doi')]
             prev_status = row[columns.index('status')]
 
-            # A status tuple of ('Pending',3) is higher than ('Draft',2) will cause an error.
+            # A status tuple of ('Pending',3) is higher than ('Draft',2) will
+            # cause an error.
             if self.m_workflow_order[prev_status.lower()] > self.m_workflow_order[doi.status.lower()]:
                 msg = (
                     f"There is a DOI record {doi_str} with status: '{prev_status.lower()}'. "
@@ -223,7 +225,6 @@ class DOIValidator:
                     f"'{doi.status}' for the lidvid: {doi.related_identifier}?"
                 )
 
-                logger.error(msg)
                 raise UnexpectedDOIActionException(msg)
 
     def validate_against_xsd(self, doi_label):


### PR DESCRIPTION
**Summary**
This PR adds support for the Draft action to consume an input OSTI XML label, either local or remote, as an alternative to PDS4 bundles. To accomplish this, the `input_util.DOIInputUtil` class has been overhauled to serve as the central location for all methods related to reading input files. A new method `parse_dois_from_input_file()` has been added that takes a file path that may correspond to a local file/directory, or remote URL. The method determines the appropriate way to parse the input based on the provide path and file extension. Additionally, a `DOIInputUtil` object can be configured with a subset of valid extensions so we can still restrict input types for different actions.

Lastly, this PR also rolls up several misc. bug fixes and improvements that were discovered while developing the feature described above. This includes a fix for #150 within the draft action.

**Test Data and/or Report**
Unit tests have been added or rewritten where necessary to test the new input logic. Additionally, the reserve tests have been rewritten using a patch for the submission to OSTI to avoid actually submitting anything.
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/5967195/test.txt)


**Related Issues**
#148 #150
