### PR TITLE
List Action Filter by Status

### DIFF
--- a/pds_doi_service/api/controllers/dois_controller.py
+++ b/pds_doi_service/api/controllers/dois_controller.py
@@ -121,8 +121,8 @@ def _records_from_dois(dois, node=None, submitter=None, osti_record=None):
     return records
 
 
-def get_dois(doi=None, submitter=None, node=None, lid=None, start_date=None,
-             end_date=None):
+def get_dois(doi=None, submitter=None, node=None, status=None, lid=None,
+             start_date=None, end_date=None):
     """
     List the DOI requests within the transaction database which match
     the specified criteria. If no criteria are provided, all database entries
@@ -137,6 +137,10 @@ def get_dois(doi=None, submitter=None, node=None, lid=None, start_date=None,
     node : list of str, optional
         List of PDS node names cited as contributor of the DOI to filter by.
         Each identifier must be one of the valid PDS steward IDs.
+    status : list of str, optional
+        List of DOI workflow status values to filter results by.
+        Each status value should correspond to one of the enumeration values in
+        DoiStatus.
     lid : list of str, optional
         List of LIDs to filter DOIs by. An LID may include the VID appended to
         the end.
@@ -167,6 +171,9 @@ def get_dois(doi=None, submitter=None, node=None, lid=None, start_date=None,
     if node:
         node = ','.join(node)
 
+    if status:
+        status = ','.join(status)
+
     lidvid = None
 
     if lid:
@@ -183,6 +190,7 @@ def get_dois(doi=None, submitter=None, node=None, lid=None, start_date=None,
         'lidvid': lidvid,
         'submitter': submitter,
         'node': node,
+        'status': status,
         'start_update': start_date,
         'end_update': end_date
     }

--- a/pds_doi_service/api/swagger/swagger.yaml
+++ b/pds_doi_service/api/swagger/swagger.yaml
@@ -53,6 +53,19 @@ paths:
           items:
             type: string
         example: eng
+      - name: status
+        in: query
+        description: List of DOI workflow status values to filter results by. Status
+          must be one of the following - "unknown", "reserved_not_submitted",  "reserved",
+          "draft", "review", "pending", or "registered".
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: array
+          items:
+            type: string
+        example: review
       - name: lid
         in: query
         description: List of LIDs to filter DOIs by. An LID may include the VID appended

--- a/pds_doi_service/api/test/test_dois_controller.py
+++ b/pds_doi_service/api/test/test_dois_controller.py
@@ -151,6 +151,23 @@ class TestDoisController(BaseTestCase):
         self.assertEqual(summary.lidvid, 'urn:nasa:pds:lab_shocked_feldspars')
         self.assertEqual(summary.status, DoiStatus.Reserved_not_submitted)
 
+        # Now try filtering by workflow status
+        query_string = [('status', DoiStatus.Reserved_not_submitted.value),
+                        ('db_name', test_db)]
+
+        response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
+                                    method='GET',
+                                    query_string=query_string)
+
+        self.assert200(
+            response,
+            'Response body is : ' + response.data.decode('utf-8')
+        )
+
+        # Should only get two of the records back
+        records = response.json
+        self.assertEqual(len(records), 2)
+
         # Finally, test with a malformed start/end date and ensure we
         # get "invalid argument" code back
         query_string = [('start_date', '2020-10-20 14:04:13.000000'),

--- a/pds_doi_service/core/actions/list.py
+++ b/pds_doi_service/core/actions/list.py
@@ -97,10 +97,18 @@ class DOICoreActionList(DOICoreAction):
         )
 
         node_values = NodeUtil.get_permissible_values()
+        status_values = [status for status in DoiStatus]
+
         action_parser.add_argument(
             '-n', '--node', required=False, metavar='"img,eng"',
             help='A list of node names comma separated to return the matching '
                  'DOI. Authorized values are: ' + ','.join(node_values)
+        )
+        action_parser.add_argument(
+            '-status', '--status', required=False, metavar="draft,review",
+            help='A list of comma-separated submission status values to pass '
+                 'as input to the database query. Valid status values are: '
+                 '{}'.format(', '.join(status_values))
         )
         action_parser.add_argument(
             '-f', '--format',  default='JSON', required=False, metavar='JSON',

--- a/pds_doi_service/core/actions/test/list_test.py
+++ b/pds_doi_service/core/actions/test/list_test.py
@@ -1,18 +1,110 @@
+#!/usr/bin/env python
+
+import json
+import os
+from os.path import abspath, dirname, join
 import unittest
+import tempfile
 
+from pds_doi_service.core.actions.draft import DOICoreActionDraft
 from pds_doi_service.core.actions.list import DOICoreActionList
+from pds_doi_service.core.actions.release import DOICoreActionRelease
+from pds_doi_service.core.entities.doi import DoiStatus
+from pds_doi_service.core.outputs.osti_web_parser import DOIOstiWebParser
 
-from pds_doi_service.core.util.general_util import get_logger
 
-logger = get_logger(__name__)
+class ListActionTestCase(unittest.TestCase):
+    # TODO: add additional unit tests for other list query parameters
 
-class MyTestCase(unittest.TestCase):
-    _action = DOICoreActionList()
+    def setUp(self):
+        self.test_dir = abspath(dirname(__file__))
+        self.input_dir = abspath(
+            join(self.test_dir, os.pardir, os.pardir, os.pardir, os.pardir, 'input')
+        )
+        self.db_name = join(self.test_dir, 'doi_temp.db')
+        self._list_action = DOICoreActionList(db_name=self.db_name)
+        self._draft_action = DOICoreActionDraft(db_name=self.db_name)
+        self._release_action = DOICoreActionRelease(db_name=self.db_name)
 
-    def test_1(self):
-        logger.info("test making a query to database")
-        result_list = self._action.run(node='img')
-        logger.info(result_list)
+    def tearDown(self):
+        if os.path.isfile(self.db_name):
+            os.remove(self.db_name)
+
+    def test_list_by_status(self):
+        """Test listing of entries, querying by workflow status"""
+        # Submit a draft, then query by draft status to retrieve
+        draft_kwargs = {
+            'input': join(self.input_dir, 'bundle_in_with_contributors.xml'),
+            'node': 'img',
+            'submitter': 'my_user@my_node.gov',
+            'force': True
+        }
+
+        draft_xml = self._draft_action.run(**draft_kwargs)
+
+        dois, _ = DOIOstiWebParser.response_get_parse_osti_xml(draft_xml)
+        doi = dois[0]
+
+        list_kwargs = {
+            'status': DoiStatus.Draft
+        }
+
+        list_result = json.loads(self._list_action.run(**list_kwargs))
+
+        self.assertEqual(len(list_result), 1)
+
+        list_result = list_result[0]
+        self.assertEqual(list_result['status'], doi.status)
+        self.assertEqual(list_result['title'], doi.title)
+        self.assertEqual(list_result['subtype'], doi.product_type_specific)
+        self.assertEqual(list_result['lid'] + '::' + list_result['vid'],
+                         doi.related_identifier)
+
+        # Now move the draft to review
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xml') as temp_file:
+            temp_file.write(draft_xml)
+            temp_file.flush()
+
+            review_kwargs = {
+                'input': temp_file.name,
+                'node': 'img',
+                'submitter': 'my_user@my_node.gov',
+                'force': True,
+                'no_review': False
+            }
+
+            review_xml = self._release_action.run(**review_kwargs)
+
+        dois, _ = DOIOstiWebParser.response_get_parse_osti_xml(review_xml)
+        doi = dois[0]
+
+        # Now query for review status
+        list_kwargs = {
+            'status': DoiStatus.Review
+        }
+
+        list_result = json.loads(self._list_action.run(**list_kwargs))
+
+        self.assertEqual(len(list_result), 1)
+
+        list_result = list_result[0]
+        self.assertEqual(list_result['status'], doi.status)
+        self.assertEqual(list_result['title'], doi.title)
+        self.assertEqual(list_result['subtype'], doi.product_type_specific)
+        self.assertEqual(list_result['lid'] + '::' + list_result['vid'],
+                         doi.related_identifier)
+
+        # Finally, query for draft status again, should get no results back
+        list_kwargs = {
+            'status': DoiStatus.Draft
+        }
+
+        list_result = json.loads(self._list_action.run(**list_kwargs))
+
+        self.assertEqual(len(list_result), 0)
+
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Summary**
This PR adds the ability to filter results retrieved by the List action by workflow status (draft, review, etc...). The logic to include status in a database query was actually already present, but never exposed as a command-line option. Such an option (`-status`/`--status`) has now been added. Additionally, status has been added as parameter to the DOI API GET dois endpoint.

**Test Data and/or Report**
Unit tests have been added for using the status option, both with the core draft action as well as the API.
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/5967950/test.txt)

**Related Issues**
#144 