### PR TITLE
Return valid xml from OSTI submission calls

### DIFF
--- a/pds_doi_service/core/actions/release.py
+++ b/pds_doi_service/core/actions/release.py
@@ -221,6 +221,20 @@ class DOICoreActionRelease(DOICoreAction):
                     i_password=self._config.get('OSTI', 'password')
                 )
                 logger.debug(f"o_release_result {dois}")
+
+                # TODO: we lose these fields when parsing dois from OSTI response.
+                #       as a temp kludge, reassign here
+                contributor = NodeUtil().get_node_long_name(self._node)
+                publisher = self._config.get('OTHER', 'doi_publisher')
+
+                for doi in dois:
+                    doi.contributor = contributor
+                    doi.publisher = publisher
+
+                # The label returned from OSTI is of a slightly different
+                # format than what we expect to pass validation, so reformat
+                # using the valid template here
+                o_doi_label = DOIOutputOsti().create_osti_doi_record(dois)
             # Otherwise, if the next step is review, recreate an OSTI label
             # from the parsed DOI's that have the "review" status assigned.
             # This becomes the label associated with the transaction database entry.

--- a/pds_doi_service/core/entities/doi.py
+++ b/pds_doi_service/core/entities/doi.py
@@ -13,7 +13,7 @@ doi.py
 Contains the dataclass and enumeration definitions for Doi objects.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, unique
 
@@ -71,7 +71,7 @@ class Doi:
     product_type_specific: str
     related_identifier: str
     authors: list = None
-    keywords: list = None
+    keywords: set = field(default_factory=set)
     editors: list = None
     description: str = None
     id: str = None

--- a/pds_doi_service/core/outputs/DOI_IAD2_template_20200205-mustache.xml
+++ b/pds_doi_service/core/outputs/DOI_IAD2_template_20200205-mustache.xml
@@ -18,7 +18,9 @@
         <availability>NASA Planetary Data System</availability>
         <publication_date>{{publication_date}}</publication_date>
         <country>USA</country>
+        {{#description}}
         <description>{{description}}</description>
+        {{/description}}
         {{#site_url}}
         <site_url>{{site_url}}</site_url>
         {{/site_url}}
@@ -28,7 +30,12 @@
         <product_type>{{product_type}}</product_type>
         <product_type_specific>{{product_type_specific}}</product_type_specific>
         <date_record_added>{{date_record_added}}</date_record_added>
+        {{#keywords}}
         <keywords>{{keywords}}</keywords>
+        {{/keywords}}
+        {{^keywords}}
+        <keywords/>
+        {{/keywords}}
         <authors>
             {{#authors}}
              <author>

--- a/pds_doi_service/core/util/doi_validator.py
+++ b/pds_doi_service/core/util/doi_validator.py
@@ -65,7 +65,13 @@ class DOIValidator:
 
     @staticmethod
     def __lidvid(columns, row):
-        return f"{row[columns.index('lid')]}::{row[columns.index('vid')]}"
+        lid = row[columns.index('lid')]
+        vid = row[columns.index('vid')]
+
+        if lid and vid:
+            return f"{row[columns.index('lid')]}::{row[columns.index('vid')]}"
+
+        return lid
 
     def _check_field_site_url(self, doi: Doi):
         """
@@ -75,7 +81,7 @@ class DOIValidator:
         logger.debug(f"doi {doi}")
         logger.info(f"doi.site_url {doi.site_url}")
 
-        if doi.site_url:
+        if doi.site_url and doi.site_url != 'N/A':
             try:
                 response = requests.get(doi.site_url, timeout=5)
                 status_code = response.status_code


### PR DESCRIPTION
**Summary**
This branch contains a fix for issue #154, where the XML label returned from a submission to OSTI (such as occurs in the reserve/release actions) was in a format that would not pass validation against their own schema. The XML returned is now reformatted using the same mustache template we use to create submission labels. Additionally, there have been several fixes to the template itself and the validation calls to ensure the XML returned from OSTI submissions is usable for later workflow actions.

**Test Data and/or Report**
No unit tests have been affected by this PR
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/6030941/test.txt)

**Related Issues**
#154
