### PR TITLE
OSTI request failure exception handling

### DIFF
--- a/pds_doi_service/core/input/exceptions.py
+++ b/pds_doi_service/core/input/exceptions.py
@@ -51,7 +51,7 @@ class IllegalDOIActionException(Exception):
 class UnexpectedDOIActionException(Exception):
     """
     Raised when a DOI has an unexpected status, or a requested action
-    circumvents the expceted DOI workflow.
+    circumvents the expected DOI workflow.
     """
     pass
 
@@ -77,6 +77,10 @@ class WarningDOIException(Exception):
 class SiteURLNotExistException(Exception):
     """Raised when a DOI's site URL cannot be reached."""
     pass
+
+
+class OSTIRequestException(Exception):
+    """Raised when a request to the OSTI service fails."""
 
 
 def collect_exception_classes_and_messages(single_exception,


### PR DESCRIPTION
**Summary**
This PR adds checks to requests made to the OSTI server, catching any `HTTPError`s (returned from the requests library) and wrapping them with a new local exception type (`OSTIRequestException`).

Here are some sample uses of the exception when using the DOI API:

Bad URL:
```json
{
  "errors": [
    {
      "message": "DOI submission request to OSTI service failed, reason: 500 Server Error:  for url: https://www.osti.gov/iad2test/api/fecords",
      "name": "OSTIRequestException"
    }
  ]
}
```

Bad credentials:
```json
{
  "errors": [
    {
      "message": "DOI submission request to OSTI service failed, reason: 401 Client Error:  for url: https://www.osti.gov/iad2test/api/records",
      "name": "OSTIRequestException"
    }
  ]
}
```

**Test Data and/or Report**
No unit tests have been updated by this PR.
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/6032047/test.txt)

**Related Issues**
#119 
