### PR TITLE
XML Label format for GET /dois/{lidvid} endpoint

### DIFF
--- a/pds_doi_service/api/controllers/dois_controller.py
+++ b/pds_doi_service/api/controllers/dois_controller.py
@@ -33,7 +33,7 @@ from pds_doi_service.core.input.exceptions import (UnknownLIDVIDException,
                                                    WarningDOIException)
 from pds_doi_service.core.input.input_util import DOIInputUtil
 from pds_doi_service.core.outputs.osti_web_parser import DOIOstiWebParser
-from pds_doi_service.core.outputs.osti import CONTENT_TYPE_XML
+from pds_doi_service.core.outputs.osti import DOIOutputOsti, CONTENT_TYPE_XML
 
 
 def _get_db_name():
@@ -522,9 +522,13 @@ def get_doi_from_id(lidvid):  # noqa: E501
     else:
         dois, _ = DOIOstiWebParser().parse_osti_response_json(osti_label_for_lidvid)
 
+    # Create a return label in XML, since this is the format expected by
+    # consumers of the response (such as the UI)
+    xml_label_for_lidvid = DOIOutputOsti().create_osti_doi_record(dois)
+
     records = _records_from_dois(
         dois, node=list_record['node_id'], submitter=list_record['submitter'],
-        osti_label=osti_label_for_lidvid
+        osti_label=xml_label_for_lidvid
     )
 
     # Should only ever be one record since we filtered by lidvid

--- a/pds_doi_service/api/swagger/swagger.yaml
+++ b/pds_doi_service/api/swagger/swagger.yaml
@@ -204,6 +204,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/doi_record'
+              example:
+              - creation_date: 2021-03-09T00:00:00Z
+                doi: 10.17189/29476
+                lidvid: urn:nasa:pds:lab_shocked_feldspars::1.0
+                node: eng
+                record: |
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <records>
+                      <record status="reserved">
+                          <id>29476</id>
+                          <title>Laboratory Shocked Feldspars Bundle</title>
+                          <doi>10.17189/29476</doi>
+                          ...
+                          <contact_name>PDS Operator</contact_name>
+                          <contact_org>PDS</contact_org>
+                          <contact_email>pds-operator@jpl.nasa.gov</contact_email>
+                          <contact_phone>818.393.7165</contact_phone>
+                      </record>
+                  </records>
+                status: reserved
+                submitter: my.email@node.gov
         "201":
           description: Success
         "400":
@@ -234,6 +255,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/doi_record'
+              example:
+              - creation_date: 2021-03-09T00:00:00Z
+                doi: 10.17189/29476
+                lidvid: urn:nasa:pds:lab_shocked_feldspars::1.0
+                node: eng
+                record: |
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <records>
+                      <record status="reserved">
+                          <id>29476</id>
+                          <title>Laboratory Shocked Feldspars Bundle</title>
+                          <doi>10.17189/29476</doi>
+                          ...
+                          <contact_name>PDS Operator</contact_name>
+                          <contact_org>PDS</contact_org>
+                          <contact_email>pds-operator@jpl.nasa.gov</contact_email>
+                          <contact_phone>818.393.7165</contact_phone>
+                      </record>
+                  </records>
+                status: reserved
+                submitter: my.email@node.gov
         "404":
           description: Not existing
         "500":


### PR DESCRIPTION
**Summary**
With the addition of JSON support for output labels, the API could return an output label in JSON format for the GET /dois/{lidvid} endpoint. This broke consumers of the response, who always expected XML. This PR updates the API controller to always return the output label in XML format.

Additionally, the swagger.yaml definition of the API has been updated to include correct examples of the 200 responses for the POST /dois and GET /dois/{lidvid} endpoints.

**Test Data and/or Report**
No unit tests modified or added by this PR.
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/6111577/test.txt)

**Related Issues**
#159 
