### PR TITLE
Fix XML Parsing Errors Reported by API

### DIFF
--- a/pds_doi_service/api/controllers/dois_controller.py
+++ b/pds_doi_service/api/controllers/dois_controller.py
@@ -28,8 +28,9 @@ from pds_doi_service.core.actions.draft import DOICoreActionDraft
 from pds_doi_service.core.actions.list import DOICoreActionList
 from pds_doi_service.core.actions.release import DOICoreActionRelease
 from pds_doi_service.core.actions.reserve import DOICoreActionReserve
-from pds_doi_service.core.input.exceptions import (UnknownLIDVIDException,
+from pds_doi_service.core.input.exceptions import (InputFormatException,
                                                    NoTransactionHistoryForLIDVIDException,
+                                                   UnknownLIDVIDException,
                                                    WarningDOIException)
 from pds_doi_service.core.input.input_util import DOIInputUtil
 from pds_doi_service.core.outputs.osti_web_parser import DOIOstiWebParser
@@ -328,7 +329,7 @@ def post_dois(action, submitter, node, url=None, body=None, force=False):
                              'Received "{}"'.format(action))
     # These exceptions indicate some kind of input error, so return the
     # Invalid Argument code
-    except (WarningDOIException, ValueError) as err:
+    except (InputFormatException, WarningDOIException, ValueError) as err:
         return format_exceptions(err), 400
     # For everything else, return the Internal Error code
     except Exception as err:

--- a/pds_doi_service/core/actions/draft.py
+++ b/pds_doi_service/core/actions/draft.py
@@ -333,8 +333,13 @@ class DOICoreActionDraft(DOICoreAction):
              exception_messages) = collect_exception_classes_and_messages(
                 err, exception_classes, exception_messages
             )
-        # Catch all other exceptions as errors
+        # Propagate input format exceptions, force flag should not affect
+        # these being raised and certain callers (such as the API) look
+        # for this exception specifically
         except InputFormatException as err:
+            raise err
+        # Catch all other exceptions as errors
+        except Exception as err:
             raise CriticalDOIException(err)
 
         # If there is at least one exception caught, either raise a

--- a/pds_doi_service/core/actions/reserve.py
+++ b/pds_doi_service/core/actions/reserve.py
@@ -24,7 +24,6 @@ from pds_doi_service.core.input.exceptions import (CriticalDOIException,
                                                    SiteURLNotExistException,
                                                    TitleDoesNotMatchProductTypeException,
                                                    UnexpectedDOIActionException,
-                                                   UnknownNodeException,
                                                    collect_exception_classes_and_messages,
                                                    raise_or_warn_exceptions)
 from pds_doi_service.core.input.input_util import DOIInputUtil
@@ -235,6 +234,11 @@ class DOICoreActionReserve(DOICoreAction):
             transaction.log()
 
             return io_doi_label
-        # Convert unhandled errors into a CriticalDOIException to report back
-        except (UnknownNodeException, InputFormatException) as err:
+        # Propagate input format exceptions, force flag should not affect
+        # these being raised and certain callers (such as the API) look
+        # for this exception specifically
+        except InputFormatException as err:
+            raise err
+        # Convert all other errors into a CriticalDOIException to report back
+        except Exception as err:
             raise CriticalDOIException(err)

--- a/pds_doi_service/core/actions/test/draft_test.py
+++ b/pds_doi_service/core/actions/test/draft_test.py
@@ -9,7 +9,7 @@ import tempfile
 from pds_doi_service.core.actions.draft import DOICoreActionDraft
 from pds_doi_service.core.actions.release import DOICoreActionRelease
 from pds_doi_service.core.entities.doi import DoiStatus, ProductType
-from pds_doi_service.core.input.exceptions import CriticalDOIException, WarningDOIException
+from pds_doi_service.core.input.exceptions import InputFormatException, CriticalDOIException, WarningDOIException
 from pds_doi_service.core.outputs.osti_web_parser import DOIOstiWebParser
 from pds_doi_service.core.outputs.osti import DOIOutputOsti
 
@@ -172,7 +172,7 @@ class DraftActionTestCase(unittest.TestCase):
             'force': True
         }
 
-        with self.assertRaises(CriticalDOIException):
+        with self.assertRaises(InputFormatException):
             self._draft_action.run(**kwargs)
 
         kwargs = {
@@ -182,7 +182,7 @@ class DraftActionTestCase(unittest.TestCase):
             'force': True
         }
 
-        with self.assertRaises(CriticalDOIException):
+        with self.assertRaises(InputFormatException):
             self._draft_action.run(**kwargs)
 
     def test_remote_collection(self):

--- a/pds_doi_service/core/input/exceptions.py
+++ b/pds_doi_service/core/input/exceptions.py
@@ -149,12 +149,12 @@ def raise_or_warn_exceptions(exception_classes, exception_messages, log=False):
         if ii == 0:
             message_to_raise = (message_to_raise
                                 + exception_classes[ii]
-                                + ':' + exception_messages[ii])
+                                + ' : ' + exception_messages[ii])
         else:
             # Add a comma after every message.
             message_to_raise = (message_to_raise
                                 + ', ' + exception_classes[ii]
-                                + ':' + exception_messages[ii])
+                                + ' : ' + exception_messages[ii])
 
     if log:
         logger.warning(message_to_raise)


### PR DESCRIPTION
**Summary***
This PR updates the handling of parsing errors for invalid PDS4/OSTI input labels such that the error details are properly propagated to the API for display back to a client. Additionally, this branch fixes a bug where such errors were returned with code 500 instead of 400.

**Test Data and/or Report**
Unit tests have been updated where necessary to accommodate new error handling fixes
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/6111630/test.txt)

**Related Issues**
#157