### PR TITLE
LIDVID Query Wildcard Support

### DIFF
--- a/pds_doi_service/api/swagger/swagger.yaml
+++ b/pds_doi_service/api/swagger/swagger.yaml
@@ -69,7 +69,7 @@ paths:
       - name: lid
         in: query
         description: List of LIDs to filter DOIs by. An LID may include the VID appended
-          to the end.
+          to the end. Each LID or LIDVID may also contain one or more Unix-style wildcards (*) to pattern match against.
         required: false
         style: form
         explode: true

--- a/pds_doi_service/core/actions/list.py
+++ b/pds_doi_service/core/actions/list.py
@@ -23,7 +23,7 @@ from pds_doi_service.core.input.exceptions import UnknownLIDVIDException
 from pds_doi_service.core.input.node_util import NodeUtil
 from pds_doi_service.core.util.general_util import get_logger
 
-logger = get_logger('pds_doi_service.core.actions.list')
+logger = get_logger(__name__)
 
 
 class DOICoreActionList(DOICoreAction):
@@ -124,13 +124,15 @@ class DOICoreActionList(DOICoreAction):
             '-lid', '--lid', required=False,
             metavar='urn:nasa:pds:lab_shocked_feldspars',
             help='A list of comma-delimited LIDs to pass as input to the '
-                 'database query.'
+                 'database query. Each LID may contain one or more wildcards '
+                 '(*) to pattern match against.'
         )
         action_parser.add_argument(
             '-lidvid', '--lidvid', required=False,
             metavar='urn:nasa:pds:lab_shocked_feldspars::1.0',
             help='A list of comma-delimited LIDVIDs to pass as input to the '
-                 'database query.'
+                 'database query. Each LIDVID may contain one or more wildcards '
+                 '(*) to pattern match against.'
         )
         action_parser.add_argument(
             '-start', '--start-update', required=False,
@@ -193,8 +195,6 @@ class DOICoreActionList(DOICoreAction):
         :param kwargs:
         :return: o_list_result:
         """
-        o_query_result = None
-
         self.parse_criteria(**kwargs)
 
         columns, rows = self._database_obj.select_latest_rows(self._query_criterias)
@@ -220,9 +220,8 @@ class DOICoreActionList(DOICoreAction):
                                     for i in range(len(columns))})
 
             o_query_result = json.dumps(result_json)
-            logger.debug(f"o_select_result {o_query_result} {type(o_query_result)}")
+            logger.debug("o_select_result: %s", o_query_result)
         else:
-            logger.error(f"Output format type {self._format} not supported yet")
-            exit(1)
+            raise ValueError(f"Output format type {self._format} is not supported.")
 
         return o_query_result

--- a/pds_doi_service/core/db/test/doi_database_test.py
+++ b/pds_doi_service/core/db/test/doi_database_test.py
@@ -1,52 +1,159 @@
+#!/usr/bin/env python
+
 import datetime
 import os
+from os.path import exists
 import unittest
+
+from pkg_resources import resource_filename
+
 from pds_doi_service.core.db.doi_database import DOIDataBase
+from pds_doi_service.core.entities.doi import DoiStatus, ProductType
 from pds_doi_service.core.util.general_util import get_logger
 
 logger = get_logger(__name__)
 
 
 class DOIDatabaseTest(unittest.TestCase):
+    """Unit tests for the doi_database.py module"""
 
-    def test_select_latest_rows(self):
-        logger.info("test selecting latest rows from database")
+    def setUp(self):
+        self._db_name = resource_filename(__name__, 'doi_temp.db')
 
-        # Delete temporary file doi_temp.db if exist for unit test.
-        if os.path.exists("doi_temp.db"):
-            os.remove("doi_temp.db")
+        # Delete temporary db if it already exists, this can occur when tests
+        # are terminated before completion (during debugging for example)
+        if exists(self._db_name):
+            os.remove(self._db_name)
 
         self._doi_database = DOIDataBase('doi_temp.db')
 
-        # Set many field values.
+    def tearDown(self):
+        if exists(self._db_name):
+            os.remove(self._db_name)
+
+    def test_select_latest_rows(self):
+        """Test selecting of latest rows from the transaction database"""
+        # Set up a sample db entry
         lid = 'urn:nasa:pds:lab_shocked_feldspars'
         vid = '1.0'
         transaction_key = 'img/2020-06-15T18:42:45.653317'
         doi = '10.17189/21729'
         transaction_date = datetime.datetime.now()
-        status = 'unknown'
+        status = DoiStatus.Unknown
         title = 'Laboratory Shocked Feldspars Bundle'
-        product_type = 'Collection'
+        product_type = ProductType.Collection
         product_type_specific = 'PDS4 Collection'
-        submitter = 'Qui.T.Chau@jpl.nasa.gov'
+        submitter = 'img-submitter@jpl.nasa.gov'
         discipline_node = 'img'
 
-        # Inserting a row in the 'doi' table.
+        # Insert a row in the 'doi' table
         self._doi_database.write_doi_info_to_database(
             lid, vid, transaction_key, doi, transaction_date, status,
             title, product_type, product_type_specific, submitter, discipline_node
         )
 
-        # Select the row we just added. The type of o_query_result should be JSON and a list of 1.
-        o_query_result = self._doi_database.select_latest_rows(query_criterias={'doi': [doi]})
+        # Select the row we just added
+        # The type of o_query_result should be JSON and a list of 1
+        o_query_result = self._doi_database.select_latest_rows(
+            query_criterias={'doi': [doi]}
+        )
 
-        logger.info(o_query_result)
+        # Reformat results to a dictionary to test with
+        query_result = dict(zip(o_query_result[0], o_query_result[1][0]))
+
+        # Ensure we got back everything we just put in
+        self.assertEqual(query_result['status'], status)
+        self.assertEqual(int(query_result['update_date']),
+                         int(transaction_date.replace(tzinfo=datetime.timezone.utc).timestamp()))
+        self.assertEqual(query_result['submitter'], submitter)
+        self.assertEqual(query_result['title'], title)
+        self.assertEqual(query_result['type'], product_type)
+        self.assertEqual(query_result['subtype'], product_type_specific)
+        self.assertEqual(query_result['node_id'], discipline_node)
+        self.assertEqual(query_result['lid'], lid)
+        self.assertEqual(query_result['vid'], vid)
+        self.assertEqual(query_result['doi'], doi)
+        self.assertEqual(query_result['transaction_key'], transaction_key)
+
+        self.assertTrue(query_result['is_latest'])
+
+        # Update some fields and write a new "latest" entry
+        status = DoiStatus.Draft
+        submitter = 'eng-submitter@jpl.nasa.gov'
+        discipline_node = 'eng'
+
+        self._doi_database.write_doi_info_to_database(
+            lid, vid, transaction_key, doi, transaction_date, status,
+            title, product_type, product_type_specific, submitter, discipline_node
+        )
+
+        # Query again and ensure we only get latest back
+        o_query_result = self._doi_database.select_latest_rows(
+            query_criterias={'doi': [doi]}
+        )
+
+        # Should only get the one row back
+        self.assertEqual(len(o_query_result[-1]), 1)
+
+        query_result = dict(zip(o_query_result[0], o_query_result[-1][0]))
+
+        self.assertEqual(query_result['status'], status)
+        self.assertEqual(query_result['submitter'], submitter)
+        self.assertEqual(query_result['node_id'], discipline_node)
+
+        self.assertTrue(query_result['is_latest'])
 
         self._doi_database.close_database()
 
-        # Remove test artifact.
-        if os.path.exists("doi_temp.db"):
-            os.remove("doi_temp.db")
+    def test_query_by_wildcard(self):
+        """
+        Test selection of database rows using tokens with wildcards for the
+        columns that support it
+        """
+        # Insert some sample rows with similar lidvids
+        num_rows = 6
+
+        for _id in range(1, 1 + num_rows):
+            lid = 'urn:nasa:pds:lab_shocked_feldspars'
+            vid = f'{_id}.0'
+            transaction_key = f'img/{_id}/2020-06-15T18:42:45.653317'
+            doi = f'10.17189/2000{_id}'
+            transaction_date = datetime.datetime.now()
+            status = DoiStatus.Draft
+            title = f'Laboratory Shocked Feldspars Bundle {_id}'
+            product_type = ProductType.Collection
+            product_type_specific = 'PDS4 Collection'
+            submitter = 'img-submitter@jpl.nasa.gov'
+            discipline_node = 'img'
+
+            self._doi_database.write_doi_info_to_database(
+                lid, vid, transaction_key, doi, transaction_date, status,
+                title, product_type, product_type_specific, submitter, discipline_node
+            )
+
+        # Use a wildcard with lidvid column to select everything we just
+        # inserted
+        o_query_result = self._doi_database.select_latest_rows(
+            query_criterias={'lidvid': ['urn:nasa:pds:lab_shocked_feldspars::*']}
+        )
+
+        # Should get all rows back
+        self.assertEqual(len(o_query_result[-1]), num_rows)
+
+        # Try again using just the lid column
+        o_query_result = self._doi_database.select_latest_rows(
+            query_criterias={'lid': ['urn:nasa:*:lab_shocked_feldspars']}
+        )
+
+        self.assertEqual(len(o_query_result[-1]), num_rows)
+
+        # Test with a combination of wildcards and full tokens
+        o_query_result = self._doi_database.select_latest_rows(
+            query_criterias={'lidvid': ['urn:nasa:pds:lab_shocked_feldspars::1.0',
+                                        'urn:nasa:pds:lab_shocked_feldspars::2.*']}
+        )
+
+        self.assertEqual(len(o_query_result[-1]), 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Summary**
This PR updates the DOI service to allow users to provide Unix-style wildcards to LID's or LIDVID's when querying the local transaction database, either via the API or using the pds-doi-cmd CLI.

There has also been some cleanup of logging statements for the affected modules.

**Test Data and/or Report**
A unit test for querying LID/LIDVID using wildcards has been added.
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/6251195/test.txt)

**Related Issues**
- resolves #177 