### PR TITLE
Title field for DoiRecord and DoiSummary

### DIFF
--- a/pds_doi_service/api/controllers/dois_controller.py
+++ b/pds_doi_service/api/controllers/dois_controller.py
@@ -117,8 +117,8 @@ def _records_from_dois(dois, node=None, submitter=None, osti_label=None):
     for doi in dois:
         records.append(
             DoiRecord(
-                doi=doi.doi, lidvid=doi.related_identifier, node=node,
-                submitter=submitter, status=doi.status,
+                doi=doi.doi, lidvid=doi.related_identifier, title=doi.title,
+                node=node, submitter=submitter, status=doi.status,
                 creation_date=doi.date_record_added,
                 update_date=doi.date_record_updated,
                 record=osti_label,
@@ -228,9 +228,9 @@ def get_dois(doi=None, submitter=None, node=None, status=None, lid=None,
 
         records.append(
             DoiSummary(
-                doi=result['doi'], lidvid=lidvid, node=result['node_id'],
-                submitter=result['submitter'], status=result['status'],
-                update_date=result['update_date']
+                doi=result['doi'], lidvid=lidvid, title=result['title'],
+                node=result['node_id'], submitter=result['submitter'],
+                status=result['status'], update_date=result['update_date']
             )
         )
 
@@ -611,7 +611,7 @@ def get_check_dois(submitter, email=False, attachment=False):
     records = [
         DoiRecord(
             doi=pending_result['doi'], lidvid=pending_result['lidvid'],
-            node=pending_result['node_id'],
+            title=pending_result['title'], node=pending_result['node_id'],
             submitter=submitter, status=pending_result['status'],
             creation_date=pending_result['release_date'],
             update_date=pending_result['update_date'],

--- a/pds_doi_service/api/models/doi_record.py
+++ b/pds_doi_service/api/models/doi_record.py
@@ -12,8 +12,8 @@ class DoiRecord(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, doi: str = None, lidvid: str = None, node: str = None,
-                 submitter: str = None, status: str = None,
+    def __init__(self, doi: str = None, lidvid: str = None, title: str = None,
+                 node: str = None, submitter: str = None, status: str = None,
                  creation_date: datetime = None, update_date: datetime = None,
                  record: str = None, message: str = None):  # noqa: E501
         """DoiRecord - a model defined in Swagger
@@ -22,6 +22,8 @@ class DoiRecord(Model):
         :type doi: str
         :param lidvid: The lidvid of this DoiRecord.  # noqa: E501
         :type lidvid: str
+        :param title: The title of this DoiRecord.  # noqa: E501
+        :type title: str
         :param node: The node of this DoiRecord.  # noqa: E501
         :type node: str
         :param submitter: The submitter of this DoiRecord.  # noqa: E501
@@ -40,6 +42,7 @@ class DoiRecord(Model):
         self.swagger_types = {
             'doi': str,
             'lidvid': str,
+            'title': str,
             'node': str,
             'submitter': str,
             'status': str,
@@ -52,6 +55,7 @@ class DoiRecord(Model):
         self.attribute_map = {
             'doi': 'doi',
             'lidvid': 'lidvid',
+            'title': 'title',
             'node': 'node',
             'submitter': 'submitter',
             'status': 'status',
@@ -62,6 +66,7 @@ class DoiRecord(Model):
         }
         self._doi = doi
         self._lidvid = lidvid
+        self._title = title
         self._node = node
         self._submitter = submitter
         self._status = status
@@ -122,6 +127,27 @@ class DoiRecord(Model):
         """
 
         self._lidvid = lidvid
+
+    @property
+    def title(self) -> str:
+        """Gets the title of this DoiRecord.
+
+
+        :return: The title of this DoiRecord.
+        :rtype: str
+        """
+        return self._title
+
+    @title.setter
+    def title(self, title: str):
+        """Sets the title of this DoiRecord.
+
+
+        :param title: The title of this DoiRecord.
+        :type title: str
+        """
+
+        self._title = title
 
     @property
     def node(self) -> str:

--- a/pds_doi_service/api/models/doi_summary.py
+++ b/pds_doi_service/api/models/doi_summary.py
@@ -12,8 +12,8 @@ class DoiSummary(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, doi: str = None, lidvid: str = None, node: str = None,
-                 submitter: str = None, status: str = None,
+    def __init__(self, doi: str = None, lidvid: str = None, title: str = None,
+                 node: str = None, submitter: str = None, status: str = None,
                  update_date: datetime = None):  # noqa: E501
         """DoiSummary - a model defined in Swagger
 
@@ -21,6 +21,8 @@ class DoiSummary(Model):
         :type doi: str
         :param lidvid: The lidvid of this DoiSummary.  # noqa: E501
         :type lidvid: str
+        :param title: The title of this DoiRecord.  # noqa: E501
+        :type title: str
         :param node: The node of this DoiSummary.  # noqa: E501
         :type node: str
         :param submitter: The submitter of this DoiSummary.  # noqa: E501
@@ -33,6 +35,7 @@ class DoiSummary(Model):
         self.swagger_types = {
             'doi': str,
             'lidvid': str,
+            'title': str,
             'node': str,
             'submitter': str,
             'status': str,
@@ -42,6 +45,7 @@ class DoiSummary(Model):
         self.attribute_map = {
             'doi': 'doi',
             'lidvid': 'lidvid',
+            'title': 'title',
             'node': 'node',
             'submitter': 'submitter',
             'status': 'status',
@@ -49,6 +53,7 @@ class DoiSummary(Model):
         }
         self._doi = doi
         self._lidvid = lidvid
+        self._title = title
         self._node = node
         self._submitter = submitter
         self._status = status
@@ -106,6 +111,27 @@ class DoiSummary(Model):
         """
 
         self._lidvid = lidvid
+
+    @property
+    def title(self) -> str:
+        """Gets the title of this DoiSummary.
+
+
+        :return: The title of this DoiSummary.
+        :rtype: str
+        """
+        return self._title
+
+    @title.setter
+    def title(self, title: str):
+        """Sets the title of this DoiSummary.
+
+
+        :param title: The title of this DoiSummary.
+        :type title: str
+        """
+
+        self._title = title
 
     @property
     def node(self) -> str:

--- a/pds_doi_service/api/swagger/swagger.yaml
+++ b/pds_doi_service/api/swagger/swagger.yaml
@@ -492,6 +492,8 @@ components:
           type: string
         lidvid:
           type: string
+        title:
+          type: string
         node:
           type: string
         submitter:
@@ -505,6 +507,7 @@ components:
         node: eng
         submitter: my.email@node.gov
         lidvid: urn:nasa:pds:lab_shocked_feldspars::1.0
+        title: Laboratory Shocked Feldspars Collection
         update_date: 2001-01-23T04:56:07.000+00:00
         doi: 10.17189/21734
         status: Pending

--- a/pds_doi_service/api/test/test_dois_controller.py
+++ b/pds_doi_service/api/test/test_dois_controller.py
@@ -98,6 +98,7 @@ class TestDoisController(BaseTestCase):
         summary = DoiSummary.from_dict(records[0])
 
         self.assertEqual(summary.node, 'eng')
+        self.assertEqual(summary.title, 'InSight Cameras Bundle 1.1')
         self.assertEqual(summary.submitter, 'eng-submitter@jpl.nasa.gov')
         self.assertEqual(summary.lidvid, 'urn:nasa:pds:insight_cameras::1.1')
         self.assertEqual(summary.status, DoiStatus.Draft)
@@ -127,6 +128,7 @@ class TestDoisController(BaseTestCase):
         summary = DoiSummary.from_dict(records[0])
 
         self.assertEqual(summary.node, 'img')
+        self.assertEqual(summary.title, 'InSight Cameras Bundle 1.0')
         self.assertEqual(summary.submitter, 'img-submitter@jpl.nasa.gov')
         self.assertEqual(summary.lidvid, 'urn:nasa:pds:insight_cameras::1.0')
         self.assertEqual(summary.status, DoiStatus.Reserved_not_submitted)
@@ -153,6 +155,7 @@ class TestDoisController(BaseTestCase):
         summary = DoiSummary.from_dict(records[0])
 
         self.assertEqual(summary.node, 'img')
+        self.assertEqual(summary.title, 'Laboratory Shocked Feldspars Bundle')
         self.assertEqual(summary.submitter, 'img-submitter@jpl.nasa.gov')
         self.assertEqual(summary.lidvid, 'urn:nasa:pds:lab_shocked_feldspars')
         self.assertEqual(summary.status, DoiStatus.Reserved_not_submitted)
@@ -230,6 +233,7 @@ class TestDoisController(BaseTestCase):
         draft_record = DoiRecord.from_dict(draft_response.json[0])
 
         self.assertEqual(draft_record.node, 'eng')
+        self.assertEqual(draft_record.title, 'InSight Cameras Bundle 1.1')
         self.assertEqual(draft_record.submitter, 'eng-submitter@jpl.nasa.gov')
         self.assertEqual(draft_record.lidvid, 'urn:nasa:pds:insight_cameras::1.1')
         # Note we get Pending back from the parsed label, however
@@ -267,6 +271,7 @@ class TestDoisController(BaseTestCase):
         draft_record = DoiRecord.from_dict(draft_response.json[0])
 
         self.assertEqual(draft_record.node, 'eng')
+        self.assertEqual(draft_record.title, 'InSight Cameras Bundle 1.1')
         self.assertEqual(draft_record.submitter, 'eng-submitter@jpl.nasa.gov')
         self.assertEqual(draft_record.lidvid, 'urn:nasa:pds:insight_cameras::1.1')
         # Note we get Pending back from the parsed label, however
@@ -322,6 +327,7 @@ class TestDoisController(BaseTestCase):
         reserve_record = DoiRecord.from_dict(reserve_response.json[0])
 
         self.assertEqual(reserve_record.node, 'img')
+        self.assertEqual(reserve_record.title, 'InSight Cameras Bundle')
         self.assertEqual(reserve_record.submitter, 'img-submitter@jpl.nasa.gov')
         self.assertEqual(reserve_record.lidvid, 'urn:nasa:pds:insight_cameras::2.0')
         self.assertEqual(reserve_record.status, DoiStatus.Reserved_not_submitted)
@@ -424,6 +430,7 @@ class TestDoisController(BaseTestCase):
         submit_record = DoiRecord.from_dict(release_response.json[0])
 
         self.assertEqual(submit_record.node, 'eng')
+        self.assertEqual(submit_record.title, 'InSight Cameras Bundle 1.1')
         self.assertEqual(submit_record.submitter, 'eng-submitter@jpl.nasa.gov')
         self.assertEqual(submit_record.lidvid, 'urn:nasa:pds:insight_cameras::1.1')
         self.assertEqual(submit_record.status, DoiStatus.Review)
@@ -493,6 +500,7 @@ class TestDoisController(BaseTestCase):
         release_record = DoiRecord.from_dict(release_response.json[0])
 
         self.assertEqual(release_record.node, 'eng')
+        self.assertEqual(release_record.title, 'InSight Cameras Bundle 1.1')
         self.assertEqual(release_record.submitter, 'eng-submitter@jpl.nasa.gov')
         self.assertEqual(release_record.lidvid, 'urn:nasa:pds:insight_cameras::1.1')
         self.assertEqual(release_record.status, DoiStatus.Pending)
@@ -664,6 +672,7 @@ class TestDoisController(BaseTestCase):
         record = DoiRecord.from_dict(response.json)
 
         self.assertEqual(record.node, 'eng')
+        self.assertEqual(record.title, 'InSight Cameras Bundle 1.1')
         self.assertEqual(record.submitter, 'eng-submitter@jpl.nasa.gov')
         self.assertEqual(record.lidvid, 'urn:nasa:pds:insight_cameras::1.1')
         self.assertEqual(record.status, DoiStatus.Pending)
@@ -689,6 +698,7 @@ class TestDoisController(BaseTestCase):
         record = DoiRecord.from_dict(response.json)
 
         self.assertEqual(record.node, 'eng')
+        self.assertEqual(record.title, 'InSight Cameras Bundle')
         self.assertEqual(record.submitter, 'eng-submitter@jpl.nasa.gov')
         self.assertEqual(record.lidvid, 'urn:nasa:pds:insight_cameras')
         self.assertEqual(record.status, DoiStatus.Pending)


### PR DESCRIPTION
**Summary**
Simple update to the `DoiRecord` and `DoiSummary` objects to include DOI title as a field returned to the API user:

<img width="634" alt="Screen Shot 2021-04-20 at 10 04 16 AM" src="https://user-images.githubusercontent.com/72415379/115436485-e6ec3f80-a1bf-11eb-98c2-a4340ca1abe1.png">


**Test Data and/or Report**
Unit tests for API controller have been updated to check for new title field.
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/6345394/test.txt)


**Related Issues**
Resolves #183
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
->