### PR TITLE
Prepare prod db

### DIFF
--- a/pds_doi_service/core/entities/doi.py
+++ b/pds_doi_service/core/entities/doi.py
@@ -63,6 +63,7 @@ class DoiStatus(str, Enum):
     Review = 'review'
     Pending = 'pending'
     Registered = 'registered'
+    Deactivated = 'deactivated'
 
 
 @dataclass

--- a/pds_doi_service/core/outputs/osti_web_parser.py
+++ b/pds_doi_service/core/outputs/osti_web_parser.py
@@ -143,10 +143,15 @@ class DOIOstiWebParser:
                         o_editors_list.append(editor_dict)
                 # Parse the node ID from the name of the data curator
                 elif contributor_type[0].text == 'DataCurator':
-                    o_node_name = full_name[0].text
-                    o_node_name = o_node_name.replace('Planetary Data System:', '')
-                    o_node_name = o_node_name.replace('Node', '')
-                    o_node_name = o_node_name.strip()
+                    if full_name:
+                        o_node_name = full_name[0].text
+                        o_node_name = o_node_name.replace('Planetary Data System:', '')
+                        o_node_name = o_node_name.replace('Node', '')
+                        o_node_name = o_node_name.strip()
+                    else:
+                        logger.info("missing DataCurator %s", etree.tostring(single_contributor))
+
+
 
         return o_editors_list, o_node_name
 

--- a/pds_doi_service/core/outputs/transaction.py
+++ b/pds_doi_service/core/outputs/transaction.py
@@ -44,6 +44,22 @@ class Transaction:
         self._transaction_disk = TransactionOnDisk()
         self._transaction_db = transaction_db
 
+    @staticmethod
+    def get_lidvid(identifier: str):
+
+        if '::' in identifier:
+            lidvid_split = identifier.split('::')
+            lid = lidvid_split[0]
+            # sometimes, at least once, the vid is duplicated
+            # in the identifier, ...::1.0::1.0,
+            # this implementation only get the first one
+            vid = lidvid_split[1]
+        else:
+            lid = identifier
+            vid = None
+
+        return lid, vid
+
     @property
     def output_content(self):
         return self._output_content
@@ -56,8 +72,8 @@ class Transaction:
         )
 
         for doi in self._dois:
-            lidvid = doi.related_identifier
-            lid, vid = lidvid.split('::')
+
+            lid, vid = Transaction.get_lidvid(doi.related_identifier)
 
             doi_fields = doi.__dict__
 

--- a/pds_doi_service/core/outputs/transaction_builder.py
+++ b/pds_doi_service/core/outputs/transaction_builder.py
@@ -54,11 +54,11 @@ class TransactionBuilder:
                              f'{",".join(VALID_CONTENT_TYPES)}')
 
         for doi in dois:
-            lidvid = doi.related_identifier
-            lid, vid = lidvid.split('::')
+
+            lid, vid = Transaction.get_lidvid(doi.related_identifier)
 
             # Get the latest available entry in the DB for this lidvid, if it exists
-            query_criteria = {'lidvid': [lidvid]} if vid else {'lid': [lid]}
+            query_criteria = {'lidvid': [doi.related_identifier]} if vid else {'lid': [lid]}
             columns, rows = self.m_doi_database.select_latest_rows(query_criteria)
 
             # Get the latest transaction record for this LIDVID so we can carry

--- a/pds_doi_service/core/util/general_util.py
+++ b/pds_doi_service/core/util/general_util.py
@@ -34,3 +34,6 @@ def get_logger(module_name=''):
     logger.setLevel(getattr(logging, logging_level.upper()))
 
     return logger
+
+
+

--- a/pds_doi_service/core/util/initialize_production_deployment.py
+++ b/pds_doi_service/core/util/initialize_production_deployment.py
@@ -140,7 +140,9 @@ def _get_node_id_from_contributors(doi_field):
     o_node_id = 'eng'
     full_name = 'dummy_full_name'  # If a 'contributors' field exist, this value will get a valid value set.
 
-    if doi_field['contributors'] and len(doi_field['contributors']) > 0:
+    if 'contributors' in doi_field.keys() \
+            and doi_field['contributors'] \
+            and len(doi_field['contributors']) > 0:
         full_name = doi_field['contributors'][0]['full_name']
         if 'Atmospheres'.lower() in full_name.lower():
             o_node_id = 'atm'
@@ -267,7 +269,9 @@ def perform_import_to_database(db_name, input, dry_run, submitter_email):
         # Get the node_id from 'contributors' field if can be found.
         node_id = _get_node_id_from_contributors(doi_field)
 
-        logger.debug(f"node_id,submitter_email,doi.contributors {node_id,submitter_email,doi.contributors}")
+        logger.debug(doi_field)
+
+        logger.debug(f"node_id,submitter_email,doi.contributors {node_id,submitter_email}")
 
         # Create a dictionary with these fields {'doi', 'status', 'title', 'product_type', 'product_type_specific'}
         # from fields in doi_field dictionary.

--- a/pds_doi_service/core/util/initialize_production_deployment.py
+++ b/pds_doi_service/core/util/initialize_production_deployment.py
@@ -56,6 +56,10 @@ from pds_doi_service.core.util.general_util import get_logger
 from pds_doi_service.core.outputs.osti_web_client import DOIOstiWebClient
 from pds_doi_service.core.outputs.osti_web_parser import DOIOstiWebParser
 
+from pds_doi_service.core.outputs.transaction_builder import TransactionBuilder
+from pds_doi_service.core.outputs.transaction import Transaction
+
+
 # Get the common logger and set the level for this file.
 logger = get_logger('pds_doi_core.util.initialize_production_deployment')
 logger.setLevel(logging.INFO)
@@ -175,6 +179,8 @@ def _get_node_id_from_contributors(doi_field):
 def perform_import_to_database(db_name, input, dry_run, submitter_email):
     # Function import all records from input (if provided) into local database.  If not provided will query from OSTI server.
     # Note that all records returned from are associated with the NASA-PDS user account.
+
+    transaction_builder = TransactionBuilder(db_name)
 
     o_records_found        = 0 # Number of records returned from OSTI.
     o_records_processed    = 0 # At the end, this value should be the same as o_records_found
@@ -298,15 +304,24 @@ def perform_import_to_database(db_name, input, dry_run, submitter_email):
 
         if not skip_db_write_flag:
             # Write a row into the database.
-            transaction_db_dao.write_doi_info_to_database(
-                lid=lidvid[0],
-                vid=lidvid[1] if len(lidvid) > 1 else None,
-                transaction_date=transaction_time,
-                submitter=submitter_email,
-                discipline_node=node_id,
-                transaction_key=transaction_io_dir,
-                **k_doi_params
+            transaction = transaction_builder.prepare_transaction(
+                node_id,
+                submitter_email,
+                [doi],
+                output_content_type='xml'
             )
+
+            transaction.log()
+
+            #transaction_db_dao.write_doi_info_to_database(
+            #    lid=lidvid[0],
+            #    vid=lidvid[1] if len(lidvid) > 1 else None,
+            #    transaction_date=transaction_time,
+            #    submitter=submitter_email,
+            #    discipline_node=node_id,
+            #    transaction_key=transaction_io_dir,
+            #    **k_doi_params
+            #)
             o_records_written += 1
 
         item_index += 1


### PR DESCRIPTION
**Summary***
I updated the script which reads data from OSTI to populate the local sqllite database.
It now also updates the transaction_history directory.

This required updates in the transaction object to handle ids which are not lidvids.

**Test Data and/or Report**
Run:
    python ./pds_doi_service/core/util/initialize_production_deployment.py -i https://www.osti.gov/iad2/api/records -s loubrieu@jpl.nasa.gov -d prod.db

**Related Issues**
- fixes: #189 