### PR TITLE
API Support for Legacy PDS3 DOIs

### DIFF
--- a/pds_doi_service/core/outputs/osti_web_parser.py
+++ b/pds_doi_service/core/outputs/osti_web_parser.py
@@ -522,31 +522,28 @@ class DOIOstiWebParser:
 
             lidvid = DOIOstiWebParser.get_lidvid_from_xml(single_record_element)
 
-            if lidvid:
-                timestamp = datetime.now()
+            timestamp = datetime.now()
 
-                publication_date = single_record_element.xpath('publication_date')[0].text
-                product_type = single_record_element.xpath('product_type')[0].text
-                product_type_specific = single_record_element.xpath('product_type_specific')[0].text
+            publication_date = single_record_element.xpath('publication_date')[0].text
+            product_type = single_record_element.xpath('product_type')[0].text
+            product_type_specific = single_record_element.xpath('product_type_specific')[0].text
 
-                doi = Doi(
-                    title=single_record_element.xpath('title')[0].text,
-                    publication_date=datetime.strptime(publication_date, '%Y-%m-%d'),
-                    product_type=ProductType(product_type),
-                    product_type_specific=product_type_specific,
-                    related_identifier=lidvid,
-                    status=DoiStatus(status.lower()),
-                    date_record_added=timestamp,
-                    date_record_updated=timestamp
-                )
+            doi = Doi(
+                title=single_record_element.xpath('title')[0].text,
+                publication_date=datetime.strptime(publication_date, '%Y-%m-%d'),
+                product_type=ProductType(product_type),
+                product_type_specific=product_type_specific,
+                related_identifier=lidvid,
+                status=DoiStatus(status.lower()),
+                date_record_added=timestamp,
+                date_record_updated=timestamp
+            )
 
-                # Parse for some optional fields that may not be present in
-                # every record from OSTI.
-                doi = DOIOstiWebParser.parse_optional_fields_xml(doi, single_record_element)
+            # Parse for some optional fields that may not be present in
+            # every record from OSTI.
+            doi = DOIOstiWebParser.parse_optional_fields_xml(doi, single_record_element)
 
-                dois.append(doi)
-
-        # end for index, single_record_element in enumerate(my_root.findall('record')):
+            dois.append(doi)
 
         return dois, errors
 
@@ -600,24 +597,23 @@ class DOIOstiWebParser:
 
             lidvid = DOIOstiWebParser.get_lidvid_from_json(record)
 
-            if lidvid:
-                timestamp = datetime.now()
+            timestamp = datetime.now()
 
-                doi = Doi(
-                    title=record['title'],
-                    publication_date=datetime.strptime(record['publication_date'], '%Y-%m-%d'),
-                    product_type=ProductType(record['product_type']),
-                    product_type_specific=record.get('product_type_specific'),
-                    related_identifier=lidvid,
-                    status=DoiStatus(record.get('status', DoiStatus.Unknown).lower()),
-                    date_record_added=timestamp,
-                    date_record_updated=timestamp
-                )
+            doi = Doi(
+                title=record['title'],
+                publication_date=datetime.strptime(record['publication_date'], '%Y-%m-%d'),
+                product_type=ProductType(record['product_type']),
+                product_type_specific=record.get('product_type_specific'),
+                related_identifier=lidvid,
+                status=DoiStatus(record.get('status', DoiStatus.Unknown).lower()),
+                date_record_added=timestamp,
+                date_record_updated=timestamp
+            )
 
-                # Parse for some optional fields that may not be present in
-                # every record from OSTI.
-                doi = DOIOstiWebParser.parse_optional_fields_json(doi, record)
+            # Parse for some optional fields that may not be present in
+            # every record from OSTI.
+            doi = DOIOstiWebParser.parse_optional_fields_json(doi, record)
 
-                dois.append(doi)
+            dois.append(doi)
 
         return dois, errors

--- a/pds_doi_service/core/outputs/osti_web_parser.py
+++ b/pds_doi_service/core/outputs/osti_web_parser.py
@@ -337,6 +337,16 @@ class DOIOstiWebParser:
                 "'report_numbers','site_url'] tags"
             )
 
+        if lidvid:
+            # Some related_identifier fields have been observed with leading and
+            # trailing whitespace, so remove it here
+            lidvid = lidvid.strip()
+
+            # Some PDS3 identifiers have been observed to contain forward
+            # slashes, which causes problems with the API endpoints, so
+            # replace them with hyphens
+            lidvid = lidvid.replace('/', '-')
+
         return lidvid
 
     @staticmethod
@@ -361,6 +371,16 @@ class DOIOstiWebParser:
                 "Expecting one of ['accession_number','identifier_type',"
                 "'report_numbers','site_url'] fields"
             )
+
+        if lidvid:
+            # Some related_identifier fields have been observed with leading and
+            # trailing whitespace, so remove it here
+            lidvid = lidvid.strip()
+
+            # Some PDS3 identifiers have been observed to contain forward
+            # slashes, which causes problems with the API endpoints, so
+            # replace them with hyphens
+            lidvid = lidvid.replace('/', '-')
 
         return lidvid
 

--- a/pds_doi_service/core/util/initialize_production_deployment.py
+++ b/pds_doi_service/core/util/initialize_production_deployment.py
@@ -1,366 +1,373 @@
-#!/bin/python
+#!/usr/bin/env python
 #
 #  Copyright 2020, by the California Institute of Technology.  ALL RIGHTS
 #  RESERVED. United States Government Sponsorship acknowledged. Any commercial
 #  use must be negotiated with the Office of Technology Transfer at the
 #  California Institute of Technology.
 #
-#------------------------------
 
-# This is a one-off script to import current DOIs from OSTI server into the production database.
-#
+"""
+===================================
+initialize_production_deployment.py
+===================================
+
+Script used to import the available DOIs from OSTI server into a local
+production database.
+"""
+
 # Parameters to this script:
 #
 #    The -s (required) is email of the PDS operator: -s pds-operator@jpl.nasa.gov
-#    The -i is optional. If the input is provided and is a file, parse from it, otherwise query from the URL input: -i https://www.osti.gov/iad2/api/records
-#        The format of input XML file is the same format of text returned from querying the OSTI server via a browser or curl command.
-#        If provided and a URL of the OSTI server, this will override the url in the config file.
-#    The -d is optional.  If provided it is the name of the database file to write records to: -d doi.db
+#    The -i is optional. If the input is provided and is a file, parse from it,
+#    otherwise query from the URL input: -i https://www.osti.gov/iad2/api/records
+#        The format of input XML file is the same format of text returned from
+#        querying the OSTI server via a browser or curl command.
+#        If provided and a URL of the OSTI server, this will override the url in
+#        the config file.
+#    The -d is optional.  If provided it is the name of the database file to
+#    write records to: -d doi.db
 #        If provided, this will override the db_name in the config file.
-#    The --dry-run parameter allows the code to parse the input or querying the server without writing to database
-#        to see how long the code takes and if there are records skipped.
-#    The --debug parameter allows the code to print debug statements useful to see if something goes wrong.
+#    The --dry-run parameter allows the code to parse the input or querying the
+#    server without writing to database to see how long the code takes and if
+#    there are records skipped.
+#    The --debug parameter allows the code to print debug statements useful to
+#    see if something goes wrong.
 #
-# Make sure the -i parameter or the url parameter in config/conf.ini points to the OPS server from OSTI 'https://www.osti.gov/iad2/api/records'
-# as the TEST server 'https://www.osti.gov/iad2test/api/records' only has test records and it takes a long time to run.
+# Make sure the -i parameter or the url parameter in config/conf.ini points to
+# the OPS server from OSTI 'https://www.osti.gov/iad2/api/records'
+# as the TEST server 'https://www.osti.gov/iad2test/api/records' only has test
+# records and it takes a long time to run.
 #
 # Example runs:
 #
-# python3 pds_doi_core/util/initialize_production_deployment.py -s pds-operator@jpl.nasa.gov -i my_input.xml -d temp.db --dry-run --debug >& t1 ; tail -20 t1
-# python3 pds_doi_core/util/initialize_production_deployment.py -s pds-operator@jpl.nasa.gov -i https://www.osti.gov/iad2/api/records -d temp.db --dry-run --debug >& t1 ; tail -20 t1
-# python3 pds_doi_core/util/initialize_production_deployment.py -s pds-operator@jpl.nasa.gov -i my_input.xml -d temp.db --debug >& t1 ; tail -20 t1
-# python3 pds_doi_core/util/initialize_production_deployment.py -s pds-operator@jpl.nasa.gov -d temp.db --debug >& t1 ; tail -20 t1
+# initialize_production_deployment.py -s pds-operator@jpl.nasa.gov -i my_input.xml -d temp.db --dry-run --debug >& t1 ; tail -20 t1
+# initialize_production_deployment.py -s pds-operator@jpl.nasa.gov -i https://www.osti.gov/iad2/api/records -d temp.db --dry-run --debug >& t1 ; tail -20 t1
+# initialize_production_deployment.py -s pds-operator@jpl.nasa.gov -i my_input.xml -d temp.db --debug >& t1 ; tail -20 t1
+# initialize_production_deployment.py -s pds-operator@jpl.nasa.gov -d temp.db --debug >& t1 ; tail -20 t1
 
-# Note: As of 10/01/2020, there is one DOI that does not have any info for lidvid that caused the software to crash.  There may be more.
-#       10.17189/1517674
-#       There is a way to update this information by querying the server with this id and update the output
-#       and feed this output with the -i parameter to this script.
+# Note: As of 10/01/2020, there is one DOI (10.17189/1517674) that does not have
+# any info for lidvid that caused the software to crash. There may be more.
+#
+#       There is a way to update this information by querying the server with
+#       this id and update the output and feed this output with the -i parameter
+#       to this script.
 #       This is the curl command:
-#           curl -v --netrc-file ~/.netrc https://www.osti.gov/iad2/api/records/1517674 -X GET -H "Content-Type: application/xml" -H "Accept: application/xml > my_input.xml
+#           curl -v --netrc-file ~/.netrc https://www.osti.gov/iad2/api/records/1517674 \
+#               -X GET -H "Content-Type: application/xml" -H "Accept: application/xml > my_input.xml
 #       Then the file my_input.xml can be edited to include the lidvid in the accession_number tag
 #           <accession_number>a:b:c::1.0</accession_number>
-# Note: As of 10/05/2020, there are 105 records that does not have info for lidvid.  Ron has been notified.
-# Note: As of 10/06/2020, there are 1058 DOIs in the OPS OSTI server associated with the NASA-PDS account.
+# Note: As of 10/05/2020, there are 105 records that does not have info for lidvid.
+#       Ron has been notified.
+# Note: As of 10/06/2020, there are 1058 DOIs in the OPS OSTI server associated
+#       with the NASA-PDS account.
 
 import argparse
 import logging
 import os
-
 from datetime import datetime
 
-from pds_doi_service.core.db.doi_database import DOIDataBase
-from pds_doi_service.core.input.exceptions import InputFormatException, CriticalDOIException
+from pds_doi_service.core.input.exceptions import (InputFormatException,
+                                                   CriticalDOIException)
+from pds_doi_service.core.outputs.osti_web_client import DOIOstiWebClient
+from pds_doi_service.core.outputs.osti_web_parser import DOIOstiWebParser
+from pds_doi_service.core.outputs.transaction_builder import TransactionBuilder
 from pds_doi_service.core.util.config_parser import DOIConfigUtil
 from pds_doi_service.core.util.general_util import get_logger
 
-from pds_doi_service.core.outputs.osti_web_client import DOIOstiWebClient
-from pds_doi_service.core.outputs.osti_web_parser import DOIOstiWebParser
-
-from pds_doi_service.core.outputs.transaction_builder import TransactionBuilder
-from pds_doi_service.core.outputs.transaction import Transaction
-
-
 # Get the common logger and set the level for this file.
-logger = get_logger('pds_doi_core.util.initialize_production_deployment')
+logger = get_logger(__name__)
 logger.setLevel(logging.INFO)
 
 m_doi_config_util = DOIConfigUtil()
 m_config = m_doi_config_util.get_config()
 
+
 def create_cmd_parser():
     parser = argparse.ArgumentParser(
-        description='Script to import existing DOIs into local database\n')
-    parser.add_argument("-i", "--input", help="Input file to import existing DOIs from or URL of OSTI server.",
-                        required=False)
-    parser.add_argument("-s", "--submitter_email", help="The email address of the user performing the initialization of deployment database.",
-                        required=True)
-    parser.add_argument("-d","--db_name", help="Optional database name instead of one from config.",
-                        required=False)
-    parser.add_argument("--dry-run", help="Flag to suppress the writing of DOIs to database.",
-                        required=False,action="store_true")
-    parser.add_argument("--debug", help="Flag to print debug statements.",
-                        required=False,action="store_true")
+        description='Script to import existing DOIs from OSTI into the local'
+                    'transaction database.'
+    )
+    parser.add_argument("-i", "--input", required=False,
+                        help="Input file to import existing DOIs from, or the "
+                             "URL of the OSTI server. If no value is provided, "
+                             "the OSTI server URL specified by the DOI service "
+                             "configuration INI file is used by default.")
+    parser.add_argument("-s", "--submitter-email", required=False,
+                        default='pds-operator@jpl.nasa.gov',
+                        help="The email address of the user performing the "
+                             "deployment database initialization. Defaults to "
+                             "pds-operator@jpl.nasa.gov.")
+    parser.add_argument("-d", "--db-name", required=False,
+                        help="Name of the SQLite3 database file name to commit "
+                             "DOI records to. If not provided, the file name is "
+                             "obtained from the DOI service INI config.")
+    parser.add_argument("--dry-run", required=False, action="store_true",
+                        help="Flag to suppress actual writing of DOIs to database.")
+    parser.add_argument("--debug", required=False, action="store_true",
+                        help="Flag to print debug statements.")
+
     return parser
 
+
 def _read_from_local_xml(path):
-    '''Function read from local xml file containing output from OSTI query.'''
+    """Read from a local xml file containing output from an OSTI query."""
     try:
         with open(path, mode='r') as f:
             doi_xml = f.read()
     except Exception as e:
         raise CriticalDOIException(str(e))
+
     dois, _ = DOIOstiWebParser.parse_osti_response_xml(doi_xml)
+
     return dois
 
-def _read_from_path(path):
-    if os.path.isfile(path):
-        if path.endswith('.xml'):
-            return _read_from_local_xml(path)
-        else:
-            logger.error(f'file {path} not supported.  Only .xml are supported.')
-            exit(1)
 
-def _parse_input(input):
-    if os.path.exists(input):
-        return _read_from_path(input)
-    else:
-        raise InputFormatException(f"Error reading file {input}.  File may not exist.")
+def _read_from_path(path):
+    if path.endswith('.xml'):
+        return _read_from_local_xml(path)
+
+    raise InputFormatException(f'File {path} is not supported. '
+                               f'Only .xml is supported.')
+
+
+def _parse_input(input_file):
+    if os.path.exists(input_file):
+        return _read_from_path(input_file)
+
+    raise InputFormatException(f"Error reading file {input_file}. "
+                               f"File may not exist.")
+
 
 def get_dois_from_osti(target_url):
-        """
-        Function query the OSTI server for all the current DOI associated with the PDS-USER account.
-        The server name is fetched from the config file with the 'url' field in 'OSTI' grouping if target_url is None.
-        :return: dois,o_server_url:
-        """
-        query_dict = {}
-        if target_url is None:
-            o_server_url = m_config.get('OSTI', 'url')
-        else:
-            o_server_url = target_url
-        logger.info(f"o_server_url {o_server_url}")
+    """
+    Queries the OSTI server for all the current DOI associated with the PDS-USER
+    account. The server name is fetched from the config file with the 'url'
+    field in the 'OSTI' grouping if target_url is None.
 
-        doi_xml = DOIOstiWebClient().webclient_query_doi(o_server_url,
-                                                         query_dict,
-                                                         i_username=m_config.get('OSTI', 'user'),
-                                                         i_password=m_config.get('OSTI', 'password'))
-        dois, _ = DOIOstiWebParser.parse_osti_response_xml(doi_xml)
+    """
+    # TODO: option to write out doi_xml as returned from OSTI
+    query_dict = {}
 
-        logger.info(f"o_server_url,len(dois) {o_server_url,len(dois)}")
+    o_server_url = target_url
 
-        return dois, o_server_url
+    if o_server_url is None:
+        o_server_url = m_config.get('OSTI', 'url')
 
-def _get_node_id_from_contributors(doi_field):
-    # Given a doi object, attempt to extract the node_id from contributors field.  If not able to, return 'eng' as default.
-    # This function is a one-off as well so no fancy logic.
-    # m_node_id_dict = {'ATM': 'Atmospheres',
-    #                  'ENG': 'Engineering',
-    #                  'GEO': 'Geosciences',
-    #                  'IMG': 'Cartography and Imaging Sciences Discipline',
-    #                  'NAIF': 'Navigational and Ancillary Information Facility',
-    #                  'PPI': 'Planetary Plasma Interactions',
-    #                  'RMS': 'Ring-Moon Systems',
-    #                  'SBN': 'Small Bodies'}
+    logger.info("Using OSTI server URL %s", o_server_url)
 
+    doi_xml = DOIOstiWebClient().webclient_query_doi(
+        o_server_url, query_dict,
+        i_username=m_config.get('OSTI', 'user'),
+        i_password=m_config.get('OSTI', 'password')
+    )
+
+    dois, _ = DOIOstiWebParser.parse_osti_response_xml(doi_xml)
+
+    return dois, o_server_url
+
+
+def _get_node_id_from_contributors(doi_fields):
+    """
+    Given a doi object, attempt to extract the node_id from contributors field.
+    If unable to, return 'eng' as default.
+    This function is a one-off as well so no fancy logic.
+    """
     o_node_id = 'eng'
-    full_name = 'dummy_full_name'  # If a 'contributors' field exist, this value will get a valid value set.
 
-    if 'contributors' in doi_field.keys() \
-            and doi_field['contributors'] \
-            and len(doi_field['contributors']) > 0:
-        full_name = doi_field['contributors'][0]['full_name']
-        if 'Atmospheres'.lower() in full_name.lower():
+    if doi_fields.get('contributor'):
+        full_name_orig = doi_fields['contributor']
+        full_name = full_name_orig.lower()
+
+        if 'atmospheres' in full_name:
             o_node_id = 'atm'
-        if 'Engineering'.lower() in full_name.lower():
-            o_node_id = 'atm'
-        if 'Geosciences'.lower() in full_name.lower():
+        elif 'engineering' in full_name:
+            o_node_id = 'eng'
+        elif 'geosciences' in full_name:
             o_node_id = 'geo'
-        if 'Imaging'.lower() in full_name.lower():
+        elif 'imaging' in full_name:
             o_node_id = 'img'
-        if 'Cartography'.lower() in full_name.lower():
+        elif 'cartography' in full_name:
             o_node_id = 'img'
         # Some uses title: Navigation and Ancillary Information Facility Node
         # Some uses title: Navigational and Ancillary Information Facility
         # So check for both
-        if 'Navigation'.lower() in full_name.lower() and 'Ancillary'.lower() in full_name.lower():
+        elif 'navigation' in full_name and 'ancillary' in full_name:
             o_node_id = 'naif'
-        if 'Navigational'.lower() in full_name.lower() and 'Ancillary'.lower() in full_name.lower():
+        elif 'navigational' in full_name and 'ancillary' in full_name:
             o_node_id = 'naif'
-        if 'Plasma'.lower() in full_name.lower():
+        elif 'plasma' in full_name:
             o_node_id = 'ppi'
-        if 'Ring'.lower() in full_name.lower() and 'Moon'.lower() in full_name.lower():
+        elif 'ring' in full_name and 'moon' in full_name:
             o_node_id = 'rms'
-        if 'Small'.lower() in full_name.lower() or 'Bodies'.lower() in full_name.lower():
+        elif 'small' in full_name or 'bodies' in full_name:
             o_node_id = 'sbn'
-        logger.debug(f"original_full_name,o_node_id {full_name},{o_node_id}")
 
-    logger.debug(f"o_node_id,full_name {o_node_id,full_name}")
+        logger.debug("Derived node ID %s from Contributor field %s",
+                     o_node_id, full_name_orig)
+    else:
+        logger.warning("No Contributor field available for DOI %s, "
+                       "defaulting to node ID %s", doi_fields['doi'], o_node_id)
+
     return o_node_id
 
-def perform_import_to_database(db_name, input, dry_run, submitter_email):
-    # Function import all records from input (if provided) into local database.  If not provided will query from OSTI server.
-    # Note that all records returned from are associated with the NASA-PDS user account.
 
-    transaction_builder = TransactionBuilder(db_name)
+def perform_import_to_database(db_name, input_source, dry_run, submitter_email):
+    """
+    Imports all records from the input source into a local database.
+    The input source may either be an existing XML file containing DOIs to parse,
+    or a URL pointing to the OSTI server to pull existing records from.
 
-    o_records_found        = 0 # Number of records returned from OSTI.
-    o_records_processed    = 0 # At the end, this value should be the same as o_records_found
-    o_records_written      = 0 # Number of records written to database.
-    o_records_dois_skipped = 0 # Number of records not processed because of missing lidvid or not start with '10.17189'.
-    o_records_valid        = 0 # Number of good or valid records with all metadata required.
-    o_pds_doi_token        = None   # Will be set to valid value if use_doi_filtering_flag is True.
+    Note that all records returned from the OSTI server are associated with the
+    NASA-PDS user account.
 
-    m_doi_config_util = DOIConfigUtil()
-    m_config = m_doi_config_util.get_config()
+    Parameters
+    ----------
+    db_name : str
+        Name of the database file to import DOI records to.
+    input_source : str
+        Either a path to an existing XML file containing OSTI DOI records to
+        parse and import, or a URL to the OSTI server to query for existing
+        records.
+    dry_run : bool
+        If true, do not actually commit any parsed DOI records to the local
+        database.
+    submitter_email : str
+        Email address of the user initiating the import.
 
-    # If flag use_doi_filtering_flag set to True, will filter only DOIs that starts with o_pds_doi_token, e.g. '10.17189'.
-    # OSTI server(s) may contain records other than expected especially the test server.
-    # For normal operation use_doi_filtering_flag should be set to False.
-    # If set to True, the parameter pds_registration_doi_token in config/conf.ini should be set to 10.17189.
+    """
+    o_records_found = 0  # Number of records returned from OSTI
+    o_records_processed = 0  # At the end, this value should be = o_records_found - o_records_skipped
+    o_records_written = 0  # Number of records actually written to database
+    o_records_dois_skipped = 0  # Number of records skipped due to missing lidvid or invalid prefix
+
+    # If use_doi_filtering_flag is set to True, we will allow only DOIs that
+    # start with the configured PDS DOI token, e.g. '10.17189'.
+    # OSTI server(s) may contain records other than expected, especially the test
+    # server. For normal operation use_doi_filtering_flag should be set to False.
+    # If set to True, the parameter pds_registration_doi_token in config/conf.ini
+    # should be set to 10.17189.
     use_doi_filtering_flag = False
-    if use_doi_filtering_flag:
-        o_pds_doi_token = m_config.get('OTHER','pds_registration_doi_token')
 
-    # If flag skip_db_write_flag set to True, will skip writing of records to database.  Use by developer to skip database write action.
+    # If flag skip_db_write_flag set to True, will skip writing of records to
+    # database.  Use by developer to skip database write action.
     # For normal operation, skip_db_write_flag should be set to False.
     skip_db_write_flag = False
+
     if dry_run:
         skip_db_write_flag = True
-    logger.info(f"skip_db_write_flag {skip_db_write_flag}")
-    logger.info(f"db_name {db_name}")
+
+    o_db_name = db_name
 
     # If db_name is not provided, get one from config file:
-    if db_name is None:
-        # This is the local database (the metadata from OSTI) will be written to.
-        o_db_name = m_config.get('OTHER','db_file')
-        # TODO: remove next line once done testing.
-        #o_db_name = 'temp_doi_temp.db'
-    else:
-        o_db_name = db_name
+    if not o_db_name:
+        # This is the local database we'll be writing to
+        o_db_name = m_config.get('OTHER', 'db_file')
 
-    logger.info(f"o_db_name {o_db_name}")
+    logger.info("Using local database %s", o_db_name)
 
-    if not o_db_name.endswith('.db'):
-        logger.error(f"File name for Sqlite3 database should end with '.db'.  Provided {o_db_name}")
-        exit(0)
+    transaction_builder = TransactionBuilder(o_db_name)
 
-    transaction_db_dao = DOIDataBase(o_db_name)
-
-    o_server_url = None
-    # If the input is provided and is a file, parse from it, otherwise query from the OSTI server.
-    if input and os.path.isfile(input):
-       dois =  _parse_input(input)
+    # If the input is provided and is a file, parse from it, otherwise query
+    # from the OSTI server.
+    if input_source and os.path.isfile(input_source):
+        dois = _parse_input(input_source)
+        o_server_url = input_source
     else:
         # Get the dois from OSTI server.
-        # Note that because the name of the server is in the config file, it can be the OPS or TEST server.
-        dois, o_server_url = get_dois_from_osti(input)
+        # Note that because the name of the server is in the config file,
+        # it can be the OPS or TEST server.
+        dois, o_server_url = get_dois_from_osti(input_source)
 
     o_records_found = len(dois)
 
-    logger.info(f"input,o_server_url,o_records_found {input,o_server_url,o_records_found}")
-
-    transaction_dir = m_config.get('OTHER','transaction_dir')
-    transaction_time = datetime.now()
-
-    # Because the database requires transaction_key to be non-null, we build one here for 'eng' node for all transactions.
-    node_id            = 'eng'
-    transaction_io_dir = os.path.join(transaction_dir, node_id, transaction_time.isoformat())
-
-    item_index = 0 # Used in debugging to show where the record is in the list.
+    logger.info("Parsed %d DOI(s) from %s", o_records_found, o_server_url)
 
     # Write each Doi object as a row into the database.
-    for doi in dois:
-
+    for item_index, doi in enumerate(dois):
         if use_doi_filtering_flag:
-            if hasattr(doi, 'doi') and not doi.doi.startswith(o_pds_doi_token):
-                logger.debug(f"SKIPPING_NON_PDS_DOI {doi.doi}")
-                o_records_dois_skipped += 1
-                o_records_processed += 1
-                item_index += 1
-                continue # Skip this record because it is not associated with the DOI group given to PDS.
+            o_pds_doi_token = m_config.get('OTHER', 'pds_registration_doi_token')
 
-        # If the field 'related_identifier' is None, we cannot proceed since database writing does not allow a None value.
-        lidvid = [None]
-        if doi.related_identifier is None:
-                logger.debug(f"SKIPPING_NONE_RELATED_IDENTIFIER {doi.doi}")
+            if doi.doi and not doi.doi.startswith(o_pds_doi_token):
+                logger.warning("Skipping non-PDS DOI %s, index %d", doi.doi,
+                               item_index)
+
                 o_records_dois_skipped += 1
-                o_records_processed += 1
-                item_index += 1
                 continue
 
-        # The lidvid is two parts separated by "::", e.g. "urn:nasa:pds:lab_shocked_feldspars_3::1.0"
-        if doi.related_identifier:
-            lidvid = doi.related_identifier.split('::')
-        doi_field = doi.__dict__  # Convert the Doi object to a dictionary.
+        # If the field 'related_identifier' is None, we cannot proceed since
+        # it serves as the primary key for our transaction database.
+        if not doi.related_identifier:
+            logger.warning("Skipping DOI with missing related identifier %s, "
+                           "index %d", doi.doi, item_index)
+
+            o_records_dois_skipped += 1
+            continue
+
+        doi_fields = doi.__dict__  # Convert the Doi object to a dictionary.
 
         # Get the node_id from 'contributors' field if can be found.
-        node_id = _get_node_id_from_contributors(doi_field)
+        node_id = _get_node_id_from_contributors(doi_fields)
 
-        logger.debug(doi_field)
-
-        logger.debug(f"node_id,submitter_email,doi.contributors {node_id,submitter_email}")
-
-        # Create a dictionary with these fields {'doi', 'status', 'title', 'product_type', 'product_type_specific'}
-        # from fields in doi_field dictionary.
-        k_doi_params = dict((k, doi_field[k]) for k in
-             doi_field.keys() & {'doi', 'status', 'title', 'product_type', 'product_type_specific'})
-
-        logger.info(f"DOI_item_only {k_doi_params['doi']}")
-        logger.info(f"DOI_item,status {k_doi_params['doi'],k_doi_params['status']}")
-
-        logger.debug(f"--------------------")
-        logger.debug(f"item_index:title {item_index,k_doi_params['title']}")
-        logger.debug(f"item_index:doi {item_index,k_doi_params['doi']}")
-        logger.debug(f"item_index:lidvid[0] {item_index,lidvid[0]}")
-        if len(lidvid) > 1:
-            logger.debug(f"item_index:lidvid[1] {item_index,lidvid[1]}")
-        logger.debug(f"item_index:transaction_time {item_index,transaction_time}")
-        logger.debug(f"item_index:submitter_email {item_index,submitter_email}")
-        logger.debug(f"item_index:node_id {item_index,node_id}")
-        logger.debug(f"item_index:transaction_io_dir {item_index,transaction_io_dir}")
-        logger.debug(f"item_index:k_doi_params {item_index,k_doi_params}")
+        logger.debug("------------------------------------")
+        logger.debug('Processed DOI at index %d', item_index)
+        logger.debug("Title: %s", doi_fields.get('title'))
+        logger.debug("DOI: %s", doi_fields.get('doi'))
+        logger.debug("Related Identifier: %s", doi_fields.get('related_identifier'))
+        logger.debug("Node ID: %s", node_id)
+        logger.debug("Status: %s", str(doi_fields.get('status', 'unknown')))
 
         o_records_processed += 1
-        o_records_valid     += 1
 
         if not skip_db_write_flag:
-            # Write a row into the database.
+            # Write a row into the database and save an output label for each
+            # DOI to the local transaction history
             transaction = transaction_builder.prepare_transaction(
                 node_id,
                 submitter_email,
-                [doi],
-                output_content_type='xml'
+                [doi]
             )
 
             transaction.log()
 
-            #transaction_db_dao.write_doi_info_to_database(
-            #    lid=lidvid[0],
-            #    vid=lidvid[1] if len(lidvid) > 1 else None,
-            #    transaction_date=transaction_time,
-            #    submitter=submitter_email,
-            #    discipline_node=node_id,
-            #    transaction_key=transaction_io_dir,
-            #    **k_doi_params
-            #)
             o_records_written += 1
 
-        item_index += 1
-    # end for doi in dois:
+    return (o_records_found, o_records_processed, o_records_written,
+            o_records_dois_skipped)
 
-    return o_server_url, o_pds_doi_token, o_records_found, o_db_name, o_records_processed, o_records_written, o_records_dois_skipped, o_records_valid
 
 def main():
+    """Entry point for initialize_production_deployment.py"""
     start_time = datetime.now()
 
-    parser = create_cmd_parser()    # Make a command parser.
-    logger.info(f"parser {parser}")
-    arguments = parser.parse_args() # Parse all the arguments.  The values can be accessed using the . dot operator
-    logger.info(f"arguments {arguments}")
-    logger.info(f"arguments.submitter_email {arguments.submitter_email}")
-    if arguments.submitter_email is None: # Value of arguments.submitter_email can be None if -s parameter becomes optional.
-        submitter_email = 'pds-operator@jpl.nasa.gov'  # Use default value
-    else:
-        submitter_email = arguments.submitter_email
-    dry_run = False
-    # Note that the parameter --dry-run (with dash) is now dry_run (with underscore) in arguments object.
-    if arguments.dry_run is not None and arguments.dry_run == True:
-        dry_run = True
-    debug_flag = False
-    if arguments.debug is not None and arguments.debug == True:
-        debug_flag = True
-        logger.setLevel(logging.DEBUG)  # Useful to see debug statements.
+    # Make a command parser and parse all the arguments.
+    # The values can be accessed using the . dot operator
+    parser = create_cmd_parser()
+    arguments = parser.parse_args()
+
+    if arguments.debug:
+        logger.setLevel(logging.DEBUG)
+
+    logger.info('Starting DOI import to local database...')
+    logger.debug('Command-line args: %r', arguments)
 
     # Do the import operation from OSTI server to database.
-    server_url, pds_doi_token, records_found, db_name, records_processed, records_written, num_dois_skipped, records_valid = perform_import_to_database(arguments.db_name,arguments.input,dry_run,submitter_email)
+    (records_found,
+     records_processed,
+     records_written,
+     records_skipped) = perform_import_to_database(arguments.db_name,
+                                                   arguments.input,
+                                                   arguments.dry_run,
+                                                   arguments.submitter_email)
 
     stop_time = datetime.now()
-    logger.info(f"server_url,pds_doi_token,records_found,db_name {server_url,pds_doi_token,records_found,db_name}")
-    logger.info(f"records_found,records_processed,records_written,num_dois_skipped,records_valid {records_found,records_processed,records_written,num_dois_skipped,records_valid}")
     elapsed_seconds = stop_time.timestamp() - start_time.timestamp()
-    logger.info(f"start_time      {start_time}")
-    logger.info(f"stop_time       {stop_time}")
-    logger.info(f"elapsed_seconds {elapsed_seconds}")
-    logger.info(f"Done with perform_import_to_database()")
+
+    logger.info("DOI import complete in %.2f seconds.", elapsed_seconds)
+    logger.info("Num records found: %d", records_found)
+    logger.info("Num records processed: %d", records_processed)
+    logger.info("Num records written: %d", records_written)
+    logger.info("Num records skipped: %d", records_skipped)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
**Summary**
This branch overhauls the `initialize_production_deployment.py` script, so that it may be used to import existing DOI entries from OSTI to a local transaction database for use with the DOI service. There are also some minor fixes to handling of identifiers assigned to PDS3 label entries, such that they work correctly with the DOI Service API.

While testing import of the existing entries from OSTI, it was observed that the identifier fields for several entries contained extraneous whitespace, and that several PDS3 id's contained forward slashes (/), which interfere with the API routing performed for the GET /dois/{lidvid} endpoint. LIDVIDs (or any identifier) parsed from labels are now tidied up to remove any extra whitespace, as well as replace any forward slashes with hyphens.

**Test Data and/or Report**
There were no updates to existing regression tests for this update
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/6474643/test.txt)

After running `initialize_production_deployment.py` against the production OSTI server, the following entries identified in #192 should now be reachable:

<img width="1434" alt="Screen Shot 2021-05-13 at 12 25 46 PM" src="https://user-images.githubusercontent.com/72415379/118176812-bd04f200-b3e6-11eb-8529-b0bb5f26fe81.png">
Note that the "LIDVID" used here is LRO-L-MRFLRO-2-3-5-BISTATIC-V3.0 (originally LRO-L-MRFLRO-2/3/5-BISTATIC-V3.0)

<img width="1432" alt="Screen Shot 2021-05-13 at 12 26 41 PM" src="https://user-images.githubusercontent.com/72415379/118176840-c2fad300-b3e6-11eb-8c0c-d21e906ee239.png">

Additionally, searching with wildcards via the GET /dois endpoint should also work correctly for PDS3 identifiers:
<img width="1179" alt="Screen Shot 2021-05-13 at 12 29 26 PM" src="https://user-images.githubusercontent.com/72415379/118177039-06edd800-b3e7-11eb-846d-77f8eb26dc04.png">


**Related Issues**
Resolves #180 (existing wildcard support already works for PDS3 identifiers)
Fixes #192
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
->