### PR TITLE
OSTI JSON Label Update Fix

### DIFF
--- a/input/DOI_Release_20210216_from_draft.json
+++ b/input/DOI_Release_20210216_from_draft.json
@@ -32,27 +32,7 @@
                 "last_name": "Maki"
             }
         ],
-        "contributors": [
-            {
-                "first_name": "P. H.",
-                "last_name": "Smith",
-                "contributor_type": "Editor"
-            },
-            {
-                "first_name": "M.",
-                "last_name": "Lemmon",
-                "contributor_type": "Editor"
-            },
-            {
-                "first_name": "R. F.",
-                "last_name": "Beebe",
-                "contributor_type": "Editor"
-            },
-            {
-                "full_name": "Planetary Data System: Cartography and Imaging Sciences Discipline Node",
-                "contributor_type": "DataCurator"
-            }
-        ],
+        "contributors": [],
         "contact_name": "PDS Operator",
         "contact_org": "PDS",
         "contact_email": "pds-operator@jpl.nasa.gov",

--- a/input/DOI_Release_20210216_from_reserve.json
+++ b/input/DOI_Release_20210216_from_reserve.json
@@ -16,28 +16,7 @@
         "product_type_specific": "PDS4 Refereed Data Bundle",
         "date_record_added": "2021-04-01",
         "keywords": "PDS;PDS4;camera;context;data;deployment;edr;engineering;experiment;insight;lander;mars;product;raw;rdr;record;reduced;science",
-        "authors": [
-            {
-                "first_name": "J.",
-                "last_name": "Maki",
-                "affiliations": []
-            },
-            {
-                "first_name": "P.",
-                "last_name": "Zamani",
-                "affiliations": []
-            },
-            {
-                "first_name": "H.",
-                "last_name": "Abarca",
-                "affiliations": []
-            },
-            {
-                "first_name": "R.",
-                "last_name": "Deen",
-                "affiliations": []
-            }
-        ],
+        "authors": [],
         "contributors": [
             {
                 "last_name": "Beebe",

--- a/src/pds_doi_service/core/actions/test/release_test.py
+++ b/src/pds_doi_service/core/actions/test/release_test.py
@@ -65,85 +65,92 @@ class ReleaseActionTestCase(unittest.TestCase):
 
     def test_reserve_release_to_review(self):
         """Test release to review status with a reserved DOI entry"""
+        # Test with both XML and JSON format labels
+        for input_label in ('DOI_Release_20200727_from_reserve.xml',
+                            'DOI_Release_20210216_from_reserve.json'):
+            release_args = {
+                'input': join(self.input_dir, input_label),
+                'node': 'img',
+                'submitter': 'img-submitter@jpl.nasa.gov',
+                'force': True,
+                'no_review': False
+            }
 
-        release_args = {
-            'input': join(self.input_dir, 'DOI_Release_20200727_from_reserve.xml'),
-            'node': 'img',
-            'submitter': 'img-submitter@jpl.nasa.gov',
-            'force': True,
-            'no_review': False
-        }
+            o_doi_label = self._action.run(**release_args)
 
-        o_doi_label = self._action.run(**release_args)
+            dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
 
-        dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-        # Should get one DOI back that has been marked as ready for review
-        self.assertEqual(len(dois), 1)
-        self.assertTrue(dois[0].status == DoiStatus.Review)
+            # Should get one DOI back that has been marked as ready for review
+            self.assertEqual(len(dois), 1)
+            self.assertTrue(dois[0].status == DoiStatus.Review)
 
     @patch.object(
         pds_doi_service.core.outputs.osti.DOIOstiWebClient,
         'submit_content', webclient_submit_patch)
     def test_reserve_release_to_osti(self):
         """Test release directly to OSTI with a reserved DOI entry"""
+        # Test with both XML and JSON format labels
+        for input_label in ('DOI_Release_20200727_from_reserve.xml',
+                            'DOI_Release_20210216_from_reserve.json'):
+            release_args = {
+                'input': join(self.input_dir, input_label),
+                'node': 'img',
+                'submitter': 'Qui.T.Chau@jpl.nasa.gov',
+                'force': True,
+                'no_review': True
+            }
 
-        release_args = {
-            'input': join(self.input_dir, 'DOI_Release_20200727_from_reserve.xml'),
-            'node': 'img',
-            'submitter': 'Qui.T.Chau@jpl.nasa.gov',
-            'force': True,
-            'no_review': True
-        }
+            o_doi_label = self._action.run(**release_args)
 
-        o_doi_label = self._action.run(**release_args)
+            dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
 
-        dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-        # Should get one DOI back that has been marked as pending registration
-        self.assertEqual(len(dois), 1)
-        self.assertTrue(dois[0].status == DoiStatus.Pending)
+            # Should get one DOI back that has been marked as pending registration
+            self.assertEqual(len(dois), 1)
+            self.assertTrue(dois[0].status == DoiStatus.Pending)
 
     def test_draft_release_to_review(self):
         """Test release to review status with a draft DOI entry"""
+        # Test with both XML and JSON format labels
+        for input_label in ('DOI_Release_20200727_from_draft.xml',
+                            'DOI_Release_20210216_from_draft.json'):
+            release_args = {
+                'input': join(self.input_dir, input_label),
+                'node': 'img',
+                'submitter': 'img-submitter@jpl.nasa.gov',
+                'force': True,
+                'no_review': False
+            }
 
-        release_args = {
-            'input': join(self.input_dir, 'DOI_Release_20200727_from_draft.xml'),
-            'node': 'img',
-            'submitter': 'img-submitter@jpl.nasa.gov',
-            'force': True,
-            'no_review': False
-        }
+            o_doi_label = self._action.run(**release_args)
 
-        o_doi_label = self._action.run(**release_args)
+            dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
 
-        dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-        # Should get one DOI back with status 'review'
-        self.assertEqual(len(dois), 1)
-        self.assertEqual(dois[0].status, DoiStatus.Review)
+            # Should get one DOI back with status 'review'
+            self.assertEqual(len(dois), 1)
+            self.assertEqual(dois[0].status, DoiStatus.Review)
 
     @patch.object(
         pds_doi_service.core.outputs.osti.DOIOstiWebClient,
         'submit_content', webclient_submit_patch)
     def test_draft_release_to_osti(self):
         """Test release directly to OSTI with a draft DOI entry"""
+        for input_label in ('DOI_Release_20200727_from_draft.xml',
+                            'DOI_Release_20210216_from_draft.json'):
+            release_args = {
+                'input': join(self.input_dir, input_label),
+                'node': 'img',
+                'submitter': 'Qui.T.Chau@jpl.nasa.gov',
+                'force': True,
+                'no_review': True
+            }
 
-        release_args = {
-            'input': join(self.input_dir, 'DOI_Release_20200727_from_draft.xml'),
-            'node': 'img',
-            'submitter': 'Qui.T.Chau@jpl.nasa.gov',
-            'force': True,
-            'no_review': True
-        }
+            o_doi_label = self._action.run(**release_args)
 
-        o_doi_label = self._action.run(**release_args)
+            dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
 
-        dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-        # Should get one DOI back with status 'pending'
-        self.assertEqual(len(dois), 1)
-        self.assertEqual(dois[0].status, DoiStatus.Pending)
+            # Should get one DOI back with status 'pending'
+            self.assertEqual(len(dois), 1)
+            self.assertEqual(dois[0].status, DoiStatus.Pending)
 
     def test_review_release_to_review(self):
         """
@@ -151,44 +158,46 @@ class ReleaseActionTestCase(unittest.TestCase):
 
         This is essentially a no-op, but it should work regardless
         """
+        for input_label in ('DOI_Release_20200727_from_review.xml',
+                            'DOI_Release_20210216_from_review.json'):
+            release_args = {
+                'input': join(self.input_dir, input_label),
+                'node': 'img',
+                'submitter': 'img-submitter@jpl.nasa.gov',
+                'force': True,
+                'no_review': False
+            }
 
-        release_args = {
-            'input': join(self.input_dir, 'DOI_Release_20200727_from_review.xml'),
-            'node': 'img',
-            'submitter': 'img-submitter@jpl.nasa.gov',
-            'force': True,
-            'no_review': False
-        }
+            o_doi_label = self._action.run(**release_args)
 
-        o_doi_label = self._action.run(**release_args)
+            dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
 
-        dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-        # Should get one DOI back with status 'review'
-        self.assertEqual(len(dois), 1)
-        self.assertEqual(dois[0].status, DoiStatus.Review)
+            # Should get one DOI back with status 'review'
+            self.assertEqual(len(dois), 1)
+            self.assertEqual(dois[0].status, DoiStatus.Review)
 
     @patch.object(
         pds_doi_service.core.outputs.osti.DOIOstiWebClient,
         'submit_content', webclient_submit_patch)
     def test_review_release_to_osti(self):
         """Test release directly to OSTI with a review DOI entry"""
+        for input_label in ('DOI_Release_20200727_from_review.xml',
+                            'DOI_Release_20210216_from_review.json'):
+            release_args = {
+                'input': join(self.input_dir, input_label),
+                'node': 'img',
+                'submitter': 'img-submitter@jpl.nasa.gov',
+                'force': True,
+                'no_review': True
+            }
 
-        release_args = {
-            'input': join(self.input_dir, 'DOI_Release_20200727_from_review.xml'),
-            'node': 'img',
-            'submitter': 'img-submitter@jpl.nasa.gov',
-            'force': True,
-            'no_review': True
-        }
+            o_doi_label = self._action.run(**release_args)
 
-        o_doi_label = self._action.run(**release_args)
+            dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
 
-        dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-        # Should get one DOI back with status 'pending'
-        self.assertEqual(len(dois), 1)
-        self.assertEqual(dois[0].status, DoiStatus.Pending)
+            # Should get one DOI back with status 'pending'
+            self.assertEqual(len(dois), 1)
+            self.assertEqual(dois[0].status, DoiStatus.Pending)
 
 
 if __name__ == '__main__':

--- a/src/pds_doi_service/core/outputs/DOI_IAD2_template_20200205-mustache.xml
+++ b/src/pds_doi_service/core/outputs/DOI_IAD2_template_20200205-mustache.xml
@@ -56,6 +56,9 @@
                 {{/full_name}}
             </author>
             {{/authors}}
+            {{^authors}}
+            <author/>
+            {{/authors}}
         </authors>
         <contributors>
             {{#editors}}

--- a/src/pds_doi_service/core/outputs/osti.py
+++ b/src/pds_doi_service/core/outputs/osti.py
@@ -724,17 +724,20 @@ class DOIOstiJsonWebParser(DOIOstiWebParser):
             )
         )
 
-        data_curator = next(
+        data_curator = list(
             filter(
                 lambda contributor: contributor['contributor_type'] == 'DataCurator',
                 contributors_record
             )
         )
 
-        o_node_name = data_curator['full_name']
-        o_node_name = o_node_name.replace('Planetary Data System:', '')
-        o_node_name = o_node_name.replace('Node', '')
-        o_node_name = o_node_name.strip()
+        o_node_name = None
+
+        if data_curator:
+            o_node_name = data_curator[0]['full_name']
+            o_node_name = o_node_name.replace('Planetary Data System:', '')
+            o_node_name = o_node_name.replace('Node', '')
+            o_node_name = o_node_name.strip()
 
         for editor in o_editors_list:
             editor.pop('contributor_type')


### PR DESCRIPTION
**Summary**
This PR fixes an issue where attempting to update the list of authors for a reserved or registered DOI entry via JSON format label would cause XML schema validation errors. A small adjustment has been made to the XML mustache template to output a valid XML label (used for validation only) even when there are no authors specified. A similar fix has been made when providing a JSON label with no contributors (editors or data curator).

**Test Data and/or Report**
Unit test suites for the reserve and release actions have been updated to cover JSON input label cases. Test data has also been modified to cover the no-authors/no-contributors cases.
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/6618734/test.txt)

Additionally, the acceptance criteria listed here https://github.com/NASA-PDS/pds-doi-service/issues/140 has been manually tested to verify that authors/contributors can be modified for existing entries via the JSON format labels:

**Existing registered entry on OSTI test server**
<img width="887" alt="Screen Shot 2021-06-08 at 9 59 28 AM" src="https://user-images.githubusercontent.com/72415379/121236183-85a12e00-c84a-11eb-84cc-93ae644a1a97.png">

**Same entry after removing authors and editors**
<img width="887" alt="Screen Shot 2021-06-08 at 10 04 10 AM" src="https://user-images.githubusercontent.com/72415379/121236346-b2eddc00-c84a-11eb-98e8-82d142db2c84.png">

**Existing reserved entry:**
<img width="886" alt="Screen Shot 2021-06-08 at 10 21 59 AM" src="https://user-images.githubusercontent.com/72415379/121236382-bbdead80-c84a-11eb-9546-2fe3becdfc8b.png">

**Reserve entry after removing authors and editors:**
<img width="884" alt="Screen Shot 2021-06-08 at 10 24 29 AM" src="https://user-images.githubusercontent.com/72415379/121236412-c731d900-c84a-11eb-9287-367f4a94c723.png">


**Related Issues**
- fixes #208 
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
->