### PR TITLE
Output Label Format Fix

### DIFF
--- a/src/pds_doi_service/api/controllers/dois_controller.py
+++ b/src/pds_doi_service/api/controllers/dois_controller.py
@@ -473,7 +473,7 @@ def post_release_doi(lidvid, force=False, **kwargs):
                 'no_review': kwargs.get('no_review', True)
             }
 
-            release_label = release_action.run(**release_kwargs)[0]
+            release_label = release_action.run(**release_kwargs)
 
         dois, errors = DOIOstiJsonWebParser.parse_dois_from_label(release_label)
 

--- a/src/pds_doi_service/core/actions/release.py
+++ b/src/pds_doi_service/core/actions/release.py
@@ -197,9 +197,9 @@ class DOICoreActionRelease(DOICoreAction):
 
         Returns
         -------
-        o_doi_label : str
-            The output label(s), reflecting the status of the released
-            input DOI's.
+        output_label : str
+            The output label, in OSTI json format, reflecting the status of the
+            released input DOI's.
         Raises
         ------
         CriticalDOIException
@@ -207,7 +207,7 @@ class DOICoreActionRelease(DOICoreAction):
             the input DOI's.
 
         """
-        output_labels = ''
+        output_dois = []
 
         self.parse_arguments(kwargs)
 
@@ -245,7 +245,9 @@ class DOICoreActionRelease(DOICoreAction):
                 # Commit the transaction to the local database
                 transaction.log()
 
-                output_labels += transaction.output_content
+                # Append the latest version of the Doi object to return
+                # as a label
+                output_dois.append(doi)
         # Propagate input format exceptions, force flag should not affect
         # these being raised and certain callers (such as the API) look
         # for this exception specifically
@@ -255,5 +257,8 @@ class DOICoreActionRelease(DOICoreAction):
         except Exception as err:
             raise CriticalDOIException(str(err))
 
-        # Return up-to-date version of output label(s)
-        return output_labels
+        output_label = DOIOstiRecord().create_doi_record(
+            output_dois, content_type=CONTENT_TYPE_JSON
+        )
+
+        return output_label

--- a/src/pds_doi_service/core/actions/reserve.py
+++ b/src/pds_doi_service/core/actions/reserve.py
@@ -190,9 +190,9 @@ class DOICoreActionReserve(DOICoreAction):
 
         Returns
         -------
-        o_doi_label : str
-            The output label(s), reflecting the status of the reserved
-            input DOI's.
+        output_label : str
+            The output label, in OSTI json format, reflecting the status of the
+            reserved input DOI's.
 
         Raises
         ------
@@ -201,7 +201,7 @@ class DOICoreActionReserve(DOICoreAction):
             the input DOI's.
 
         """
-        output_labels = ''
+        output_dois = []
 
         self.parse_arguments(kwargs)
 
@@ -233,7 +233,9 @@ class DOICoreActionReserve(DOICoreAction):
                 # Commit the transaction to the local database
                 transaction.log()
 
-                output_labels += transaction.output_content
+                # Append the latest version of the Doi object to return
+                # as a label
+                output_dois.append(doi)
 
         # Propagate input format exceptions, force flag should not affect
         # these being raised and certain callers (such as the API) look
@@ -244,5 +246,8 @@ class DOICoreActionReserve(DOICoreAction):
         except Exception as err:
             raise CriticalDOIException(err)
 
-        # Return up-to-date version of output label(s)
-        return output_labels
+        output_label = DOIOstiRecord().create_doi_record(
+            output_dois, content_type=CONTENT_TYPE_JSON
+        )
+
+        return output_label

--- a/src/pds_doi_service/core/actions/test/draft_test.py
+++ b/src/pds_doi_service/core/actions/test/draft_test.py
@@ -336,7 +336,7 @@ class DraftActionTestCase(unittest.TestCase):
                 'force': True
             }
 
-            review_osti_doi = self._review_action.run(**review_kwargs)[0]
+            review_osti_doi = self._review_action.run(**review_kwargs)
 
         dois, errors = DOIOstiJsonWebParser.parse_dois_from_label(review_osti_doi)
 

--- a/src/pds_doi_service/core/actions/test/list_test.py
+++ b/src/pds_doi_service/core/actions/test/list_test.py
@@ -75,7 +75,7 @@ class ListActionTestCase(unittest.TestCase):
                 'no_review': False
             }
 
-            review_json = self._release_action.run(**review_kwargs)[0]
+            review_json = self._release_action.run(**review_kwargs)
 
         dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(review_json)
         doi = dois[0]

--- a/src/pds_doi_service/core/actions/test/release_test.py
+++ b/src/pds_doi_service/core/actions/test/release_test.py
@@ -68,6 +68,35 @@ class ReleaseActionTestCase(unittest.TestCase):
 
         return doi, o_doi_label
 
+    def run_release_test(self, release_args, expected_dois, expected_status):
+        """
+        Helper function to run the release action and check the expected number
+        of DOI records and DOI status returned.
+
+        Parameters
+        ----------
+        release_args - dict
+            The keyword arguments to pass to the release action run method
+        expected_dois - int
+            The number of DOI records expected from the release action
+        expected_status - DoiStatus
+            The expected status of each returned record
+
+        """
+        o_doi_label = self._action.run(**release_args)
+
+        dois, errors = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
+
+        # Should get the expected number of parsed DOI's
+        self.assertEqual(len(dois), expected_dois)
+
+        # Shouldn't be any errors returned
+        self.assertEqual(len(errors), 0)
+
+        # Each DOI should have the expected status set
+        for doi in dois:
+            self.assertEqual(doi.status, expected_status)
+
     def test_reserve_release_to_review(self):
         """Test release to review status with a reserved DOI entry"""
 
@@ -79,14 +108,9 @@ class ReleaseActionTestCase(unittest.TestCase):
             'no_review': False
         }
 
-        o_doi_labels = self._action.run(**release_args)
-
-        for o_doi_label in o_doi_labels:
-            dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-            # Should get one DOI back that has been marked as ready for review
-            self.assertEqual(len(dois), 1)
-            self.assertTrue(dois[0].status == DoiStatus.Review)
+        self.run_release_test(
+            release_args, expected_dois=1, expected_status=DoiStatus.Review
+        )
 
     @patch.object(
         pds_doi_service.core.outputs.osti.osti_web_client.DOIOstiWebClient,
@@ -102,14 +126,9 @@ class ReleaseActionTestCase(unittest.TestCase):
             'no_review': True
         }
 
-        o_doi_labels = self._action.run(**release_args)
-
-        for o_doi_label in o_doi_labels:
-            dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-            # Should get one DOI back that has been marked as pending registration
-            self.assertEqual(len(dois), 1)
-            self.assertTrue(dois[0].status == DoiStatus.Pending)
+        self.run_release_test(
+            release_args, expected_dois=1, expected_status=DoiStatus.Pending
+        )
 
     def test_draft_release_to_review(self):
         """Test release to review status with a draft DOI entry"""
@@ -122,14 +141,9 @@ class ReleaseActionTestCase(unittest.TestCase):
             'no_review': False
         }
 
-        o_doi_labels = self._action.run(**release_args)
-
-        for o_doi_label in o_doi_labels:
-            dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-            # Should get one DOI back with status 'review'
-            self.assertEqual(len(dois), 1)
-            self.assertEqual(dois[0].status, DoiStatus.Review)
+        self.run_release_test(
+            release_args, expected_dois=1, expected_status=DoiStatus.Review
+        )
 
     @patch.object(
         pds_doi_service.core.outputs.osti.osti_web_client.DOIOstiWebClient,
@@ -145,14 +159,9 @@ class ReleaseActionTestCase(unittest.TestCase):
             'no_review': True
         }
 
-        o_doi_labels = self._action.run(**release_args)
-
-        for o_doi_label in o_doi_labels:
-            dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-            # Should get one DOI back with status 'pending'
-            self.assertEqual(len(dois), 1)
-            self.assertEqual(dois[0].status, DoiStatus.Pending)
+        self.run_release_test(
+            release_args, expected_dois=1, expected_status=DoiStatus.Pending
+        )
 
     def test_review_release_to_review(self):
         """
@@ -169,14 +178,9 @@ class ReleaseActionTestCase(unittest.TestCase):
             'no_review': False
         }
 
-        o_doi_labels = self._action.run(**release_args)
-
-        for o_doi_label in o_doi_labels:
-            dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-            # Should get one DOI back with status 'review'
-            self.assertEqual(len(dois), 1)
-            self.assertEqual(dois[0].status, DoiStatus.Review)
+        self.run_release_test(
+            release_args, expected_dois=1, expected_status=DoiStatus.Review
+        )
 
     @patch.object(
         pds_doi_service.core.outputs.osti.osti_web_client.DOIOstiWebClient,
@@ -192,14 +196,9 @@ class ReleaseActionTestCase(unittest.TestCase):
             'no_review': True
         }
 
-        o_doi_labels = self._action.run(**release_args)
-
-        for o_doi_label in o_doi_labels:
-            dois, _ = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-            # Should get one DOI back with status 'pending'
-            self.assertEqual(len(dois), 1)
-            self.assertEqual(dois[0].status, DoiStatus.Pending)
+        self.run_release_test(
+            release_args, expected_dois=1, expected_status=DoiStatus.Pending
+        )
 
 
 if __name__ == '__main__':

--- a/src/pds_doi_service/core/actions/test/reserve_test.py
+++ b/src/pds_doi_service/core/actions/test/reserve_test.py
@@ -18,10 +18,9 @@ from pds_doi_service.core.outputs.web_client import WEB_METHOD_POST
 
 class ReserveActionTestCase(unittest.TestCase):
 
-    db_name = 'doi_temp.db'
-
     def setUp(self):
         # This setUp() function is called for every test.
+        self.db_name = 'doi_temp.db'
         self._action = DOICoreActionReserve(db_name=self.db_name)
         self.test_dir = resource_filename(__name__, '')
         self.input_dir = abspath(
@@ -55,6 +54,35 @@ class ReserveActionTestCase(unittest.TestCase):
 
         return doi, o_doi_label
 
+    def run_reserve_test(self, reserve_args, expected_dois, expected_status):
+        """
+        Helper function to run the release action and check the expected number
+        of DOI records and DOI status returned.
+
+        Parameters
+        ----------
+        reserve_args - dict
+            The keyword arguments to pass to the reserve action run method
+        expected_dois - int
+            The number of DOI records expected from the reserve action
+        expected_status - DoiStatus
+            The expected status of each returned record
+
+        """
+        o_doi_label = self._action.run(**reserve_args)
+
+        dois, errors = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
+
+        # Should get the expected number of parsed DOI's
+        self.assertEqual(len(dois), expected_dois)
+
+        # Shouldn't be any errors returned
+        self.assertEqual(len(errors), 0)
+
+        # Each DOI should have the expected status set
+        for doi in dois:
+            self.assertEqual(doi.status, expected_status)
+
     def test_reserve_xlsx_dry_run(self):
         """
         Test Reserve action with a local excel spreadsheet, using the
@@ -69,14 +97,9 @@ class ReserveActionTestCase(unittest.TestCase):
             'force': True
         }
 
-        o_doi_labels = self._action.run(**reserve_args)
-
-        for o_doi_label in o_doi_labels:
-            dois, errors = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-            self.assertEqual(len(dois), 1)
-            self.assertEqual(len(errors), 0)
-            self.assertTrue(dois[0].status == DoiStatus.Reserved_not_submitted)
+        self.run_reserve_test(
+            reserve_args, expected_dois=3, expected_status=DoiStatus.Reserved_not_submitted
+        )
 
     @patch.object(
         pds_doi_service.core.outputs.osti.osti_web_client.DOIOstiWebClient,
@@ -95,14 +118,9 @@ class ReserveActionTestCase(unittest.TestCase):
             'force': True
         }
 
-        o_doi_labels = self._action.run(**reserve_args)
-
-        for o_doi_label in o_doi_labels:
-            dois, errors = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-            self.assertEqual(len(dois), 1)
-            self.assertEqual(len(errors), 0)
-            self.assertTrue(dois[0].status == DoiStatus.Reserved)
+        self.run_reserve_test(
+            reserve_args, expected_dois=3, expected_status=DoiStatus.Reserved
+        )
 
     def test_reserve_csv_dry_run(self):
         """
@@ -117,14 +135,9 @@ class ReserveActionTestCase(unittest.TestCase):
             'force': True
         }
 
-        o_doi_labels = self._action.run(**reserve_args)
-
-        for o_doi_label in o_doi_labels:
-            dois, errors = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-            self.assertEqual(len(dois), 1)
-            self.assertEqual(len(errors), 0)
-            self.assertTrue(dois[0].status == DoiStatus.Reserved_not_submitted)
+        self.run_reserve_test(
+            reserve_args, expected_dois=3, expected_status=DoiStatus.Reserved_not_submitted
+        )
 
     @patch.object(
         pds_doi_service.core.outputs.osti.osti_web_client.DOIOstiWebClient,
@@ -141,14 +154,9 @@ class ReserveActionTestCase(unittest.TestCase):
             'force': True
         }
 
-        o_doi_labels = self._action.run(**reserve_args)
-
-        for o_doi_label in o_doi_labels:
-            dois, errors = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-            self.assertEqual(len(dois), 1)
-            self.assertEqual(len(errors), 0)
-            self.assertTrue(dois[0].status == DoiStatus.Reserved)
+        self.run_reserve_test(
+            reserve_args, expected_dois=3, expected_status=DoiStatus.Reserved
+        )
 
     def test_reserve_json_dry_run(self):
         """
@@ -163,14 +171,9 @@ class ReserveActionTestCase(unittest.TestCase):
             'force': True
         }
 
-        o_doi_labels = self._action.run(**reserve_args)
-
-        for o_doi_label in o_doi_labels:
-            dois, errors = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-            self.assertEqual(len(dois), 1)
-            self.assertEqual(len(errors), 0)
-            self.assertTrue(dois[0].status == DoiStatus.Reserved_not_submitted)
+        self.run_reserve_test(
+            reserve_args, expected_dois=1, expected_status=DoiStatus.Reserved_not_submitted
+        )
 
     @patch.object(
         pds_doi_service.core.outputs.osti.DOIOstiWebClient,
@@ -187,14 +190,9 @@ class ReserveActionTestCase(unittest.TestCase):
             'force': True
         }
 
-        o_doi_labels = self._action.run(**reserve_args)
-
-        for o_doi_label in o_doi_labels:
-            dois, errors = DOIOstiJsonWebParser.parse_dois_from_label(o_doi_label)
-
-            self.assertEqual(len(dois), 1)
-            self.assertEqual(len(errors), 0)
-            self.assertTrue(dois[0].status == DoiStatus.Reserved)
+        self.run_reserve_test(
+            reserve_args, expected_dois=1, expected_status=DoiStatus.Reserved
+        )
 
 
 if __name__ == '__main__':

--- a/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
+++ b/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
@@ -1,69 +1,73 @@
 {
     "data":
-    {
-        {% if doi.doi %}"id": "{{ doi.doi }}",{% endif %}
-        "type": "dois",
-        "attributes": {
-            {% if doi.status.value == "reserved" %}"event": "register",{% elif doi.status.value == "pending" %}"event": "publish",{% endif %}
-            {% if doi.doi %}"doi": "{{ doi.doi }}",{% else %}"prefix": "{{ doi.prefix }}",{% endif %}
-            {% if doi.id %}"suffix": "{{ doi.id }}",{% endif %}
-            "creators": [{% for author in doi.authors %}
-                {
-                    "nameType": "Personal",
-                    "name": "{{ author['last_name'] }}, {{ author['first_name'] }}",
-                    "givenName": "{{ author['first_name'] }}",
-                    "familyName": "{{ author['last_name'] }}"
-                }{% if not loop.last %},{% endif %}{% endfor %}
-            ],
-            "titles": [
-                {
-                    "title": "{{ doi.title }}",
-                    "lang": "en"
-                }
-            ],
-            "publisher": "{{ doi.publisher }}",
-            "publicationYear": "{{ doi.publication_year }}",
-            "subjects": [{% for keyword in doi.keywords %}
-                { "subject": "{{ keyword }}" }{% if not loop.last %},{% endif %}{% endfor %}
-            ],
-            "contributors": [{% for editor in doi.editors %}
-                {
-                    "nameType": "Personal",
-                    "name": "{{ editor['last_name'] }}, {{ editor['first_name'] }}",
-                    "givenName": "{{ editor['first_name'] }}",
-                    "familyName": "{{ editor['last_name'] }}",
-                    "contributorType": "Editor"
-                }, {% endfor %}
-                {
-                    "nameType": "Organizational",
-                    "name": "Planetary Data System: {{ doi.contributor }} Node",
-                    "contributorType": "DataCurator"
-                }
-            ],
-            "types": {
-                "resourceTypeGeneral": "{{ doi.product_type.value }}",
-                "resourceType": "{{ doi.product_type_specific }}"
-            },
-            "relatedIdentifiers": [
-                {
-                    "relatedIdentifier": "{{ doi.related_identifier }}",
-                    "relatedIdentifierType": "URN",
-                    "relationType": "HasMetadata",
-                    "resourceTypeGeneral": "Text"
-                }
-            ],
-            {% if doi.description %}"descriptions": [
-                {
-                    "description": "{{ doi.description }}",
-                    "descriptionType": "Abstract",
-                    "lang": "en"
-                }
-            ],{% endif %}
-            {% if doi.site_url %}"url": "{{ doi.site_url }}",{% else %}"url": ":tba",{% endif %}
-            {% if doi.date_record_added %}"created": "{{ doi.date_record_added }}",{% endif %}
-            {% if doi.date_record_updated %}"updated": "{{ doi.date_record_updated }}",{% endif %}
-            "state": "{{ doi.status.value }}",
-            "language": "en"
-        }
-    }
+    {% if dois|length > 1 %}[{% endif -%}
+    {% for doi in dois %}
+        {
+            {% if doi.doi %}"id": "{{ doi.doi }}",{% endif -%}
+            "type": "dois",
+            "attributes": {
+                {% if doi.status.value == "reserved" %}"event": "register",{% elif doi.status.value == "pending" %}"event": "publish",{% endif %}
+                {% if doi.doi %}"doi": "{{ doi.doi }}",{% else %}"prefix": "{{ doi.prefix }}",{% endif %}
+                {% if doi.id %}"suffix": "{{ doi.id }}",{% endif %}
+                "creators": [{% for author in doi.authors %}
+                    {
+                        "nameType": "Personal",
+                        "name": "{{ author['last_name'] }}, {{ author['first_name'] }}",
+                        "givenName": "{{ author['first_name'] }}",
+                        "familyName": "{{ author['last_name'] }}"
+                    }{% if not loop.last %},{% endif %}{% endfor %}
+                ],
+                "titles": [
+                    {
+                        "title": "{{ doi.title }}",
+                        "lang": "en"
+                    }
+                ],
+                "publisher": "{{ doi.publisher }}",
+                "publicationYear": "{{ doi.publication_year }}",
+                "subjects": [{% for keyword in doi.keywords %}
+                    { "subject": "{{ keyword }}" }{% if not loop.last %},{% endif %}{% endfor %}
+                ],
+                "contributors": [{% for editor in doi.editors %}
+                    {
+                        "nameType": "Personal",
+                        "name": "{{ editor['last_name'] }}, {{ editor['first_name'] }}",
+                        "givenName": "{{ editor['first_name'] }}",
+                        "familyName": "{{ editor['last_name'] }}",
+                        "contributorType": "Editor"
+                    }, {% endfor %}
+                    {
+                        "nameType": "Organizational",
+                        "name": "Planetary Data System: {{ doi.contributor }} Node",
+                        "contributorType": "DataCurator"
+                    }
+                ],
+                "types": {
+                    "resourceTypeGeneral": "{{ doi.product_type.value }}",
+                    "resourceType": "{{ doi.product_type_specific }}"
+                },
+                "relatedIdentifiers": [
+                    {
+                        "relatedIdentifier": "{{ doi.related_identifier }}",
+                        "relatedIdentifierType": "URN",
+                        "relationType": "HasMetadata",
+                        "resourceTypeGeneral": "Text"
+                    }
+                ],
+                {% if doi.description %}"descriptions": [
+                    {
+                        "description": "{{ doi.description }}",
+                        "descriptionType": "Abstract",
+                        "lang": "en"
+                    }
+                ],{% endif %}
+                {% if doi.site_url %}"url": "{{ doi.site_url }}",{% else %}"url": ":tba",{% endif %}
+                {% if doi.date_record_added %}"created": "{{ doi.date_record_added }}",{% endif %}
+                {% if doi.date_record_updated %}"updated": "{{ doi.date_record_updated }}",{% endif %}
+                "state": "{{ doi.status.value }}",
+                "language": "en"
+            }
+        }{% if not loop.last %},{% endif -%}
+    {% endfor %}
+    {% if dois|length > 1 %}]{% endif %}
 }

--- a/src/pds_doi_service/core/outputs/datacite/datacite_web_parser.py
+++ b/src/pds_doi_service/core/outputs/datacite/datacite_web_parser.py
@@ -54,23 +54,26 @@ class DOIDataCiteWebParser(DOIWebParser):
                 return record['suffix']
             else:
                 # Parse the ID from the DOI field, it it's available
-                return DOIDataCiteWebParser._parse_doi(record).split('/')[-1]
-        except KeyError as err:
-            logger.warning('Could not parse id from record, reason: %s', err)
+                return record.get('doi').split('/')[-1]
+        except (AttributeError, KeyError) as err:
+            logger.warning('Could not parse id from record, reason: %s %s',
+                           err.__class__, err)
 
     @staticmethod
     def _parse_doi(record):
         try:
             return record['doi']
         except KeyError as err:
-            logger.warning('Could not parse doi from record, reason: %s', err)
+            logger.warning('Could not parse doi from record, reason: %s %s',
+                           err.__class__, err)
 
     @staticmethod
     def _parse_description(record):
         try:
             return record['descriptions'][0]['description']
         except (IndexError, KeyError) as err:
-            logger.warning('Could not parse description from record, reason: %s', err)
+            logger.warning('Could not parse description from record, reason: %s %s',
+                           err.__class__, err)
 
     @staticmethod
     def _parse_keywords(record):
@@ -78,7 +81,8 @@ class DOIDataCiteWebParser(DOIWebParser):
             return set(sorted(subject['subject']
                               for subject in record['subjects']))
         except KeyError as err:
-            logger.warning('Could not parse keywords from record, reason: %s', err)
+            logger.warning('Could not parse keywords from record, reason: %s %s',
+                           err.__class__, err)
 
     @staticmethod
     def _parse_authors(record):
@@ -87,14 +91,16 @@ class DOIDataCiteWebParser(DOIWebParser):
                      'last_name': creator['familyName']}
                     for creator in record['creators']]
         except KeyError as err:
-            logger.warning('Could not parse authors from record, reason: %s', err)
+            logger.warning('Could not parse authors from record, reason: %s %s',
+                           err.__class__, err)
 
     @staticmethod
     def _parse_site_url(record):
         try:
             return html.unescape(record['url'])
         except KeyError as err:
-            logger.warning('Could not parse site url from record, reason: %s', err)
+            logger.warning('Could not parse site url from record, reason: %s %s',
+                           err.__class__, err)
 
     @staticmethod
     def _parse_editors(record):
@@ -104,28 +110,32 @@ class DOIDataCiteWebParser(DOIWebParser):
                     for contributor in record['contributors']
                     if contributor['contributorType'] == 'Editor']
         except KeyError as err:
-            logger.warning('Could not parse editors from record, reason: %s', err)
+            logger.warning('Could not parse editors from record, reason: %s %s',
+                           err.__class__, err)
 
     @staticmethod
     def _parse_status(record):
         try:
             return DoiStatus(record['state'])
         except (KeyError, ValueError) as err:
-            logger.warning('Could not parse status from record, reason: %s', err)
+            logger.warning('Could not parse status from record, reason: %s %s',
+                           err.__class__, err)
 
     @staticmethod
     def _parse_date_record_added(record):
         try:
             return isoparse(record['created'])
         except (KeyError, ValueError) as err:
-            logger.warning('Could not parse date added from record, reason: %s', err)
+            logger.warning('Could not parse date added from record, reason: %s %s',
+                           err.__class__, err)
 
     @staticmethod
     def _parse_date_record_updated(record):
         try:
             return isoparse(record['updated'])
         except (KeyError, ValueError) as err:
-            logger.warning('Could not parse date updated from record, reason: %s', err)
+            logger.warning('Could not parse date updated from record, reason: %s %s',
+                           err.__class__, err)
 
     @staticmethod
     def _parse_contributor(record):
@@ -143,7 +153,8 @@ class DOIDataCiteWebParser(DOIWebParser):
 
             return contributor
         except (KeyError, StopIteration, ValueError) as err:
-            logger.warning('Could not parse a contributor from record, reason: %s', err)
+            logger.warning('Could not parse a contributor from record, reason: %s %s',
+                           err.__class__, err)
 
     @staticmethod
     def _parse_related_identifier(record):
@@ -155,7 +166,7 @@ class DOIDataCiteWebParser(DOIWebParser):
                 return DOIWebParser._get_lidvid_from_site_url(record['url'])
             else:
                 logger.warning('Could not parse a related identifier from record, '
-                               'reason: %s', err)
+                               'reason: %s %s', err.__class__, err)
 
     @staticmethod
     def _parse_title(record):
@@ -163,7 +174,8 @@ class DOIDataCiteWebParser(DOIWebParser):
             return record['titles'][0]['title']
         except (IndexError, KeyError) as err:
             raise InputFormatException(
-                f'Failed to parse title from provided record, reason: {err}'
+                f'Failed to parse title from provided record, reason: '
+                f'{err.__class__} {err}'
             )
 
     @staticmethod
@@ -172,7 +184,8 @@ class DOIDataCiteWebParser(DOIWebParser):
             return record['publisher']
         except KeyError as err:
             raise InputFormatException(
-                f'Failed to parse publisher from provided record, reason: {err}'
+                f'Failed to parse publisher from provided record, reason: '
+                f'{err.__class__} {err}'
             )
 
     @staticmethod
@@ -182,7 +195,7 @@ class DOIDataCiteWebParser(DOIWebParser):
         except (KeyError, ValueError) as err:
             raise InputFormatException(
                 'Failed to parse publication date from provided record, reason: '
-                f'{err}'
+                f'{err.__class__} {err}'
             )
 
     @staticmethod
@@ -192,7 +205,7 @@ class DOIDataCiteWebParser(DOIWebParser):
         except (KeyError, ValueError) as err:
             raise InputFormatException(
                 'Failed to parse product type from provided record, reason: '
-                f'{err}'
+                f'{err.__class__} {err}'
             )
 
     @staticmethod
@@ -202,7 +215,7 @@ class DOIDataCiteWebParser(DOIWebParser):
         except KeyError as err:
             raise InputFormatException(
                 'Failed to parse product type specific from provided record, '
-                f'reason: {err}'
+                f'reason: {err.__class__} {err}'
             )
 
     @staticmethod

--- a/src/pds_doi_service/core/outputs/doi_record.py
+++ b/src/pds_doi_service/core/outputs/doi_record.py
@@ -23,15 +23,15 @@ VALID_CONTENT_TYPES = [CONTENT_TYPE_JSON, CONTENT_TYPE_XML]
 
 class DOIRecord:
     """Abstract base class for DOI record generating classes"""
-    def create_doi_record(self, doi, content_type=CONTENT_TYPE_XML):
+    def create_doi_record(self, dois, content_type=CONTENT_TYPE_XML):
         """
         Creates a DOI record from the provided list of Doi objects in the
         specified format.
 
         Parameters
         ----------
-        doi : Doi
-            The Doi object to format into the returned record.
+        dois : Doi or list of Doi
+            The Doi object(s) to format into the returned record.
         content_type : str
             The type of record to return.
 

--- a/src/pds_doi_service/core/outputs/osti/DOI_IAD2_template_20210216-mustache.json
+++ b/src/pds_doi_service/core/outputs/osti/DOI_IAD2_template_20210216-mustache.json
@@ -59,6 +59,6 @@
         "contact_org": "PDS",
         "contact_email": "pds-operator@jpl.nasa.gov",
         "contact_phone": "818.393.7165"
-    }
+    }{{#comma}},{{/comma}}
     {{/dois}}
 ]


### PR DESCRIPTION
**Summary** 
During the initial addition of the DataCite functionality, the interface to record rendering classes (in outputs/doi_record.py) was updated to only create an output record for a single `Doi` object at a time. This had the unexpected consequence of disrupting the workflow for the command-line tool, where it was expected to output a parsable record after each transaction.

This PR reverts the usage of the DOIRecord class and its inheritors to accept multiple `Doi` objects and render them in a single output label, which can then be saved off and resubmitted later as a valid OSTI/DataCite format input.

**Test Data and/or Report**
Regression tests have been updated where necessary to account for changes to the rendering of the output record.
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/6772034/test.txt)

This PR should also resolve any errors currently in the pytest suite.


**Related Issues**
#219 
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
->