### PR TITLE
DataCite Metadata Update

### DIFF
--- a/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
+++ b/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
@@ -10,9 +10,7 @@
             {% endif %}
             "type": "dois",
             "attributes": {
-                {% if doi.status.value == "reserved" %}
-                "event": "register",
-                {% elif doi.status.value == "pending" %}
+                {% if doi.status.value == "pending" %}
                 "event": "publish",
                 {% elif doi.status.value == "findable" %}
                 "event": "hide",

--- a/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
+++ b/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
@@ -1,21 +1,37 @@
 {
     "data":
-    {% if dois|length > 1 %}[{% endif -%}
+    {% if dois|length > 1 %}
+    [
+    {% endif %}
     {% for doi in dois %}
         {
-            {% if doi.doi %}"id": "{{ doi.doi }}",{% endif -%}
+            {% if doi.doi %}
+            "id": "{{ doi.doi }}",
+            {% endif %}
             "type": "dois",
             "attributes": {
-                {% if doi.status.value == "reserved" %}"event": "register",{% elif doi.status.value == "pending" %}"event": "publish",{% endif %}
-                {% if doi.doi %}"doi": "{{ doi.doi }}",{% else %}"prefix": "{{ doi.prefix }}",{% endif %}
-                {% if doi.id %}"suffix": "{{ doi.id }}",{% endif %}
-                "creators": [{% for author in doi.authors %}
+                {% if doi.status.value == "reserved" %}
+                "event": "register",
+                {% elif doi.status.value == "pending" %}
+                "event": "publish",
+                {% endif %}
+                {% if doi.doi %}
+                "doi": "{{ doi.doi }}",
+                {% else %}
+                "prefix": "{{ doi.prefix }}",
+                {% endif %}
+                {% if doi.id %}
+                "suffix": "{{ doi.id }}",
+                {% endif %}
+                "creators": [
+                    {% for author in doi.authors %}
                     {
                         "nameType": "Personal",
                         "name": "{{ author['last_name'] }}, {{ author['first_name'] }}",
                         "givenName": "{{ author['first_name'] }}",
                         "familyName": "{{ author['last_name'] }}"
-                    }{% if not loop.last %},{% endif %}{% endfor %}
+                    }{% if not loop.last %},{% endif +%}
+                    {% endfor %}
                 ],
                 "titles": [
                     {
@@ -25,17 +41,21 @@
                 ],
                 "publisher": "{{ doi.publisher }}",
                 "publicationYear": "{{ doi.publication_year }}",
-                "subjects": [{% for keyword in doi.keywords %}
-                    { "subject": "{{ keyword }}" }{% if not loop.last %},{% endif %}{% endfor %}
+                "subjects": [
+                    {% for keyword in doi.keywords %}
+                    { "subject": "{{ keyword }}" }{% if not loop.last %},{% endif +%}
+                    {% endfor %}
                 ],
-                "contributors": [{% for editor in doi.editors %}
+                "contributors": [
+                    {% for editor in doi.editors %}
                     {
                         "nameType": "Personal",
                         "name": "{{ editor['last_name'] }}, {{ editor['first_name'] }}",
                         "givenName": "{{ editor['first_name'] }}",
                         "familyName": "{{ editor['last_name'] }}",
                         "contributorType": "Editor"
-                    }, {% endfor %}
+                    },
+                    {% endfor %}
                     {
                         "nameType": "Organizational",
                         "name": "Planetary Data System: {{ doi.contributor }} Node",
@@ -54,20 +74,30 @@
                         "resourceTypeGeneral": "Text"
                     }
                 ],
-                {% if doi.description %}"descriptions": [
+                {% if doi.description %}
+                "descriptions": [
                     {
                         "description": "{{ doi.description }}",
                         "descriptionType": "Abstract",
                         "lang": "en"
                     }
-                ],{% endif %}
-                {% if doi.site_url %}"url": "{{ doi.site_url }}",{% else %}"url": ":tba",{% endif %}
-                {% if doi.date_record_added %}"created": "{{ doi.date_record_added }}",{% endif %}
-                {% if doi.date_record_updated %}"updated": "{{ doi.date_record_updated }}",{% endif %}
+                ],
+                {% endif %}
+                {% if doi.site_url %}
+                "url": "{{ doi.site_url }}",
+                {% endif %}
+                {% if doi.date_record_added %}
+                "created": "{{ doi.date_record_added }}",
+                {% endif %}
+                {% if doi.date_record_updated %}
+                "updated": "{{ doi.date_record_updated }}",
+                {% endif %}
                 "state": "{{ doi.status.value }}",
                 "language": "en"
             }
-        }{% if not loop.last %},{% endif -%}
+        }{% if not loop.last %},{% endif +%}
     {% endfor %}
-    {% if dois|length > 1 %}]{% endif %}
+    {% if dois|length > 1 %}
+    ]
+    {% endif %}
 }

--- a/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
+++ b/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
@@ -14,6 +14,8 @@
                 "event": "register",
                 {% elif doi.status.value == "pending" %}
                 "event": "publish",
+                {% elif doi.status.value == "findable" %}
+                "event": "hide",
                 {% endif %}
                 {% if doi.doi %}
                 "doi": "{{ doi.doi }}",

--- a/src/pds_doi_service/core/outputs/datacite/datacite_record.py
+++ b/src/pds_doi_service/core/outputs/datacite/datacite_record.py
@@ -50,7 +50,9 @@ class DOIDataCiteRecord(DOIRecord):
             )
 
         with open(self._json_template_path, 'r') as infile:
-            self._template = jinja2.Template(infile.read())
+            self._template = jinja2.Template(
+                infile.read(), lstrip_blocks=True, trim_blocks=True
+            )
 
     def create_doi_record(self, dois, content_type=CONTENT_TYPE_JSON):
         """

--- a/src/pds_doi_service/core/outputs/datacite/datacite_web_parser.py
+++ b/src/pds_doi_service/core/outputs/datacite/datacite_web_parser.py
@@ -98,7 +98,7 @@ class DOIDataCiteWebParser(DOIWebParser):
     def _parse_site_url(record):
         try:
             return html.unescape(record['url'])
-        except KeyError as err:
+        except (KeyError, TypeError) as err:
             logger.warning('Could not parse site url from record, reason: %s %s',
                            err.__class__, err)
 

--- a/src/pds_doi_service/core/outputs/test/datacite_test.py
+++ b/src/pds_doi_service/core/outputs/test/datacite_test.py
@@ -83,6 +83,17 @@ class DOIDataCiteRecordTestCase(unittest.TestCase):
         self.assertIn('event', release_label_dict['data']['attributes'])
         self.assertEqual(release_label_dict['data']['attributes']['event'], 'publish')
 
+        # If updating a record that has already been published (findable),
+        # we need to move it back to the registered stage via the "hide" event
+        test_doi.status = DoiStatus.Findable
+
+        back_to_reserve_label = DOIDataCiteRecord().create_doi_record(test_doi)
+
+        back_to_reserve_label_dict = json.loads(back_to_reserve_label)
+
+        self.assertIn('event', back_to_reserve_label_dict['data']['attributes'])
+        self.assertEqual(back_to_reserve_label_dict['data']['attributes']['event'], 'hide')
+
         # For any other state, we should not get an event field in the label
         test_doi.status = DoiStatus.Reserved_not_submitted
 

--- a/src/pds_doi_service/core/outputs/test/datacite_test.py
+++ b/src/pds_doi_service/core/outputs/test/datacite_test.py
@@ -65,16 +65,8 @@ class DOIDataCiteRecordTestCase(unittest.TestCase):
                        contributor='Engineering',
                        status=DoiStatus.Reserved)
 
-        # Create the label to submit to DataCite, since the Doi has been set
-        # to reserve, the label should contain the "register" event
-        reserve_label = DOIDataCiteRecord().create_doi_record(test_doi)
-        reserve_label_dict = json.loads(reserve_label)
-
-        self.assertIn('event', reserve_label_dict['data']['attributes'])
-        self.assertEqual(reserve_label_dict['data']['attributes']['event'], 'register')
-
-        # Now test with the Pending (release) state, which should map to the
-        # "publish" event
+        # Create the label to submit to DataCite, using  the Pending (release)
+        # state, which should map to the "publish" event
         test_doi.status = DoiStatus.Pending
 
         release_label = DOIDataCiteRecord().create_doi_record(test_doi)


### PR DESCRIPTION
**Summary**
This PR addresses the ability to update DOI metadata once a record has been submitted to DataCite. Much of the required functionality was already available from previous commits, so this branch merely address a corner case where a record in the "findable" state must be moved back to "registered" via the "hide" event before it is updated.

The branch also adds some niceties to the formatting of the Jinja2 template and fixes a potential parsing error for DataCite records.

**EDIT**: Added a commit to remove support for the DataCite "registered" state, since we determined that the "draft" state was sufficient for the PDS DOI workflow

**Test Data and/or Report**
Unit tests have been updated to account for changes to the DataCite template
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/6811310/test.txt)

Acceptance criteria are addressed here:
[175_acceptance_criteria.pptx](https://github.com/NASA-PDS/pds-doi-service/files/6811316/175_acceptance_criteria.pptx)
Note that there was one criteria that is not addressed by this PR, and will merit further discussion.

**Related Issues**
Resolves #175 
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
->