### PR TITLE
DOI API Referrer Check

### DIFF
--- a/src/pds_doi_service/api/__main__.py
+++ b/src/pds_doi_service/api/__main__.py
@@ -7,8 +7,10 @@
 #
 
 import logging
+from urllib.parse import urlparse
 
 import connexion
+from flask import jsonify
 from flask_cors import CORS
 from waitress import serve
 
@@ -17,6 +19,118 @@ from pds_doi_service.core.util.config_parser import DOIConfigUtil
 from pds_doi_service.core.util.general_util import get_logger
 
 logging.basicConfig(level=logging.INFO)
+
+# We create the connexion app here so we can access underlying Flask decorators
+app = connexion.App(__name__, specification_dir='swagger/')
+# We also add an initialization flag to ensure that calls to init_app() only
+# add the swagger api once
+app.initialized = False
+
+
+class InvalidReferrer(Exception):
+    """Raised when the referrer check fails."""
+    status_code = 401
+
+    def __init__(self, message, status_code=None):
+        Exception.__init__(self)
+        self.message = message
+
+        if status_code is not None:
+            self.status_code = status_code
+
+    def to_dict(self):
+        rv = {'message': self.message, 'status_code': self.status_code}
+        return rv
+
+
+@app.app.errorhandler(InvalidReferrer)
+def handle_invalid_usage(error):
+    """Registers a handler for InvalidReferrer exceptions caught by Flask"""
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    return response
+
+
+@app.app.before_request
+def _check_referrer():
+    """
+    Checks the referrer header field of the current request to ensure it was
+    sent by a valid endpoint. The list of valid referrers is defined by the
+    DOI service INI config. If not valid referrers are defined by the config,
+    this function will allow all requests through.
+
+    Raises
+    ------
+    InvalidReferrer
+        If no referrer is provided with the request, or the referrer is not
+        within the list of valid hosts.
+
+    Returns
+    -------
+    None if the referrer is valid (meaning the request should continue).
+
+    """
+    logger = logging.getLogger(__name__)
+    config = DOIConfigUtil().get_config()
+
+    valid_referrers = config.get('OTHER', 'api_valid_referrers')
+    valid_referrers = list(map(str.strip, valid_referrers.split(',')))
+    logger.debug("Valid referrers: %s", valid_referrers)
+
+    # if no valid referrers are configured, just return None to allow
+    # request to go forward
+    if not valid_referrers:
+        return None
+
+    referrer = connexion.request.referrer
+    logger.debug("Referrer: %s", referrer)
+
+    if not referrer:
+        raise InvalidReferrer('No referrer specified from request')
+
+    parsed_referrer = urlparse(referrer)
+
+    if (parsed_referrer.hostname not in valid_referrers
+            and referrer not in valid_referrers):
+        raise InvalidReferrer(
+            'Request referrer is not allowed access to the API',
+            status_code=403
+        )
+
+
+def init_app():
+    """
+    Performs one-time initialization on the Connexion application that serves
+    the DOI API. This includes feeding in the swagger OpenAPI YAML file
+    that defines the operations of the API.
+
+    Initialization is only performed on the first call to this function. All
+    future calls only return a handle to the app itself. This makes the function
+    safe for use with the flask_testing package.
+
+    Returns
+    -------
+    app : Connexion.App
+        The initialized Connexion (Flask) application
+
+    """
+    if not app.initialized:
+        CORS(app.app)
+        app.app.json_encoder = encoder.JSONEncoder
+
+        # Disable the Flask "strict_slashes" checking so endpoints with a trailing
+        # slash resolve to the same endpoint as without
+        app.app.url_map.strict_slashes = False
+
+        # Feed the swagger definition to the connexion app, this informs the
+        # app how to route URL's to endpoints in dois_controller.py
+        app.add_api('swagger.yaml',
+                    arguments={'title': 'Planetary Data System DOI Service API'},
+                    pythonic_params=True)
+
+        app.initialized = True
+
+    return app
 
 
 def main():
@@ -38,19 +152,8 @@ def main():
 
     logger.info(f'Logging system configured at level {logging_level}')
 
-    app = connexion.App(__name__, specification_dir='swagger/')
-    CORS(app.app)
-    app.app.json_encoder = encoder.JSONEncoder
-
-    # Disable the Flask "strict_slashes" checking so endpoints with a trailing
-    # slash resolve to the same endpoint as without
-    app.app.url_map.strict_slashes = False
-
-    # Feed the swagger definition to the connexion app, this informs the
-    # app how to route URL's to endpoints in dois_controller.py
-    app.add_api('swagger.yaml',
-                arguments={'title': 'Planetary Data System DOI Service API'},
-                pythonic_params=True)
+    # Initialize the Connexion (Flask) application
+    app = init_app()
 
     # Set the log level of waitress to match the configured level
     get_logger('waitress')

--- a/src/pds_doi_service/api/test/_base.py
+++ b/src/pds_doi_service/api/test/_base.py
@@ -1,13 +1,12 @@
 # encoding: utf-8
 
-'''
+"""
 Planetary Data System's Digital Object Identifier service — API testing base classes
-'''
+"""
 
 
 from flask_testing import TestCase
-from pds_doi_service.api.encoder import JSONEncoder
-import connexion
+from pds_doi_service.api.__main__ import init_app
 import logging
 
 
@@ -15,8 +14,5 @@ class BaseTestCase(TestCase):
 
     def create_app(self):
         logging.getLogger('connexion.operation').setLevel('ERROR')
-        app = connexion.App(__name__, specification_dir='../swagger/')
-        app.app.json_encoder = JSONEncoder
-        app.app.url_map.strict_slashes = False
-        app.add_api('swagger.yaml')
+        app = init_app()
         return app.app

--- a/src/pds_doi_service/api/test/test_dois_controller.py
+++ b/src/pds_doi_service/api/test/test_dois_controller.py
@@ -25,9 +25,10 @@ from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_XML
 
 class TestDoisController(BaseTestCase):
     """DoisController integration test stubs"""
-    # This attribute is defined at class level so it may be accessed
+    # These attributes are defined at class level so it may be accessed
     # by patched methods
     test_data_dir = None
+    input_dir = None
 
     @classmethod
     def setUpClass(cls):
@@ -113,7 +114,8 @@ class TestDoisController(BaseTestCase):
 
         for endpoint in endpoints:
             response = self.client.open(endpoint, method='GET',
-                                        query_string=query_string)
+                                        query_string=query_string,
+                                        headers={'Referer': 'http://localhost'})
 
             self.assert200(
                 response,
@@ -131,7 +133,8 @@ class TestDoisController(BaseTestCase):
 
         response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
                                     method='GET',
-                                    query_string=query_string)
+                                    query_string=query_string,
+                                    headers={'Referer': 'http://localhost'})
 
         self.assert200(
             response,
@@ -161,7 +164,8 @@ class TestDoisController(BaseTestCase):
 
         response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
                                     method='GET',
-                                    query_string=query_string)
+                                    query_string=query_string,
+                                    headers={'Referer': 'http://localhost'})
 
         self.assert200(
             response,
@@ -188,7 +192,8 @@ class TestDoisController(BaseTestCase):
 
         response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
                                     method='GET',
-                                    query_string=query_string)
+                                    query_string=query_string,
+                                    headers={'Referer': 'http://localhost'})
 
         self.assert200(
             response,
@@ -214,7 +219,8 @@ class TestDoisController(BaseTestCase):
 
         response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
                                     method='GET',
-                                    query_string=query_string)
+                                    query_string=query_string,
+                                    headers={'Referer': 'http://localhost'})
 
         self.assert200(
             response,
@@ -233,7 +239,8 @@ class TestDoisController(BaseTestCase):
 
         response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
                                     method='GET',
-                                    query_string=query_string)
+                                    query_string=query_string,
+                                    headers={'Referer': 'http://localhost'})
 
         self.assert400(
             response,
@@ -260,7 +267,8 @@ class TestDoisController(BaseTestCase):
 
         draft_response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
                                           method='POST',
-                                          query_string=query_string)
+                                          query_string=query_string,
+                                          headers={'Referer': 'http://localhost'})
 
         self.assert200(
             draft_response,
@@ -306,7 +314,8 @@ class TestDoisController(BaseTestCase):
                                           method='POST',
                                           data=body,
                                           content_type='application/xml',
-                                          query_string=query_string)
+                                          query_string=query_string,
+                                          headers={'Referer': 'http://localhost'})
 
         self.assert200(
             draft_response,
@@ -358,7 +367,8 @@ class TestDoisController(BaseTestCase):
                                             method='POST',
                                             data=JSONEncoder().encode(body),
                                             content_type='application/json',
-                                            query_string=query_string)
+                                            query_string=query_string,
+                                            headers={'Referer': 'http://localhost'})
 
         self.assert200(
             reserve_response,
@@ -386,7 +396,8 @@ class TestDoisController(BaseTestCase):
 
         error_response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
                                           method='POST',
-                                          query_string=query_string)
+                                          query_string=query_string,
+                                          headers={'Referer': 'http://localhost'})
 
         self.assert400(
             error_response,
@@ -401,7 +412,8 @@ class TestDoisController(BaseTestCase):
 
         error_response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
                                           method='POST',
-                                          query_string=query_string)
+                                          query_string=query_string,
+                                          headers={'Referer': 'http://localhost'})
 
         self.assert400(
             error_response,
@@ -419,7 +431,8 @@ class TestDoisController(BaseTestCase):
 
         error_response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
                                           method='POST',
-                                          query_string=query_string)
+                                          query_string=query_string,
+                                          headers={'Referer': 'http://localhost'})
 
         self.assert400(
             error_response,
@@ -438,7 +451,8 @@ class TestDoisController(BaseTestCase):
             '/PDS_APIs/pds_doi_api/0.1/dois/{lidvid}/submit'
                 .format(lidvid='urn:nasa:pds:insight_cameras::1.1'),
             method='POST',
-            query_string=query_string
+            query_string=query_string,
+            headers={'Referer': 'http://localhost'}
         )
 
         self.assert200(
@@ -482,9 +496,10 @@ class TestDoisController(BaseTestCase):
 
         release_response = self.client.open(
             '/PDS_APIs/pds_doi_api/0.1/dois/{lidvid}/release'
-                .format(lidvid='urn:nasa:pds:insight_cameras::1.1'),
+            .format(lidvid='urn:nasa:pds:insight_cameras::1.1'),
             method='POST',
-            query_string=query_string
+            query_string=query_string,
+            headers={'Referer': 'http://localhost'}
         )
 
         self.assert404(
@@ -508,7 +523,8 @@ class TestDoisController(BaseTestCase):
             '/PDS_APIs/pds_doi_api/0.1/dois/{lidvid}/release'
             .format(lidvid='urn:nasa:pds:insight_cameras::1.1'),
             method='POST',
-            query_string=query_string
+            query_string=query_string,
+            headers={'Referer': 'http://localhost'}
         )
 
         self.assert200(
@@ -561,7 +577,8 @@ class TestDoisController(BaseTestCase):
             '/PDS_APIs/pds_doi_api/0.1/dois/{lidvid}/release'
             .format(lidvid='urn:nasa:pds:insight_cameras::1.1'),
             method='POST',
-            query_string=query_string
+            query_string=query_string,
+            headers={'Referer': 'http://localhost'}
         )
 
         self.assert400(
@@ -605,7 +622,8 @@ class TestDoisController(BaseTestCase):
             '/PDS_APIs/pds_doi_api/0.1/dois/{lidvid}/release'
             .format(lidvid='urn:nasa:pds:insight_cameras::1.1'),
             method='POST',
-            query_string=query_string
+            query_string=query_string,
+            headers={'Referer': 'http://localhost'}
         )
 
         self.assert404(
@@ -653,7 +671,8 @@ class TestDoisController(BaseTestCase):
             '/PDS_APIs/pds_doi_api/0.1/dois/{lidvid}/release'
             .format(lidvid='urn:nasa:pds:insight_cameras::1.1'),
             method='POST',
-            query_string=query_string
+            query_string=query_string,
+            headers={'Referer': 'http://localhost'}
         )
 
         self.assert500(
@@ -680,7 +699,8 @@ class TestDoisController(BaseTestCase):
         response = self.client.open(
             '/PDS_APIs/pds_doi_api/0.1/dois/{lidvid}'
             .format(lidvid='urn:nasa:pds:insight_cameras::1.1'),
-            method='GET'
+            method='GET',
+            headers={'Referer': 'http://localhost'}
         )
 
         self.assert200(
@@ -708,7 +728,8 @@ class TestDoisController(BaseTestCase):
         response = self.client.open(
             '/PDS_APIs/pds_doi_api/0.1/dois/{lidvid}'
             .format(lidvid='urn:nasa:pds:insight_cameras'),
-            method='GET'
+            method='GET',
+            headers={'Referer': 'http://localhost'}
         )
 
         self.assert200(
@@ -738,7 +759,8 @@ class TestDoisController(BaseTestCase):
         error_response = self.client.open(
             '/PDS_APIs/pds_doi_api/0.1/dois/{lidvid}'
             .format(lidvid='urn:nasa:pds:insight_cameras::1.1'),
-            method='GET'
+            method='GET',
+            headers={'Referer': 'http://localhost'}
         )
 
         self.assert404(
@@ -768,7 +790,8 @@ class TestDoisController(BaseTestCase):
         error_response = self.client.open(
             '/PDS_APIs/pds_doi_api/0.1/dois/{lidvid}'
             .format(lidvid='urn:nasa:pds:insight_cameras::1.1'),
-            method='GET'
+            method='GET',
+            headers={'Referer': 'http://localhost'}
         )
 
         self.assert500(
@@ -797,7 +820,8 @@ class TestDoisController(BaseTestCase):
             '/PDS_APIs/pds_doi_api/0.1/dois/{lidvid}'
             .format(lidvid='urn:nasa:pds:insight_cameras::1.1'),
             method='PUT',
-            query_string=query_string
+            query_string=query_string,
+            headers={'Referer': 'http://localhost'}
         )
 
         # Should return a Not Implemented code
@@ -814,7 +838,8 @@ class TestDoisController(BaseTestCase):
         response = self.client.open(
             '/PDS_APIs/pds_doi_api/0.1/dois/{lidvid}'
             .format(lidvid='urn:nasa:pds:insight_cameras::1.1'),
-            method='PUT'
+            method='PUT',
+            headers={'Referer': 'http://localhost'}
         )
 
         self.assertEqual(response.status_code, 501)
@@ -863,7 +888,8 @@ class TestDoisController(BaseTestCase):
 
         response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois/check',
                                     method='GET',
-                                    query_string=query_string)
+                                    query_string=query_string,
+                                    headers={'Referer': 'http://localhost'})
 
         self.assert200(
             response,
@@ -888,6 +914,41 @@ class TestDoisController(BaseTestCase):
                 self.assertEqual(record['status'], DoiStatus.Error)
                 # Make sure we got a message back with the error
                 self.assertIsNotNone(record['message'])
+
+    def test_filter_by_referrers(self):
+        """Test filtering of requests based on the referer header value"""
+
+        # By default, the INI config should specify localhost and 0.0.0.0 as
+        # valid hostnames, so attempting with any other referrer should
+        # return a 403 "forbidden" error
+        response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
+                                    method='GET',
+                                    headers={'Referer': 'http://www.zombo.com'})
+
+        self.assert403(
+            response,
+            'Response body is : ' + response.data.decode('utf-8')
+        )
+
+        # Requests with no referrer provided should also fail with a 401
+        # "unauthorized" error
+        response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
+                                    method='GET')
+
+        self.assert401(
+            response,
+            'Response body is : ' + response.data.decode('utf-8')
+        )
+
+        # Providing a valid referrer should make everything work again
+        response = self.client.open('/PDS_APIs/pds_doi_api/0.1/dois',
+                                    method='GET',
+                                    headers={'Referer': 'http://0.0.0.0'})
+
+        self.assert200(
+            response,
+            'Response body is : ' + response.data.decode('utf-8')
+        )
 
 
 if __name__ == '__main__':

--- a/src/pds_doi_service/core/input/input_util.py
+++ b/src/pds_doi_service/core/input/input_util.py
@@ -262,8 +262,8 @@ class DOIInputUtil:
         num_rows = len(csv_sheet.index)
 
         logger.debug("csv_sheet.head(): %s", str(csv_sheet.head()))
-        logger.debug("num_cols: %d", str(num_cols))
-        logger.debug("num_rows: %d", str(num_rows))
+        logger.debug("num_cols: %d", num_cols)
+        logger.debug("num_rows: %d", num_rows)
         logger.debug("data columns: %s", str(list(csv_sheet.columns)))
 
         if num_cols < self.EXPECTED_NUM_COLUMNS:

--- a/src/pds_doi_service/core/util/conf.ini.default
+++ b/src/pds_doi_service/core/util/conf.ini.default
@@ -32,6 +32,7 @@ db_file = doi.db
 db_table = doi
 api_host = 0.0.0.0
 api_port = 8080
+api_valid_referrers = localhost, 0.0.0.0
 emailer_local_host = localhost
 emailer_port       = 25
 emailer_sender     = pdsen-doi-test@jpl.nasa.gov


### PR DESCRIPTION
**Summary**
This PR enhances the DOI API application to filter all incoming requests based on the setting of the referrer header field.

There is now a `api_valid_referrers` field in the INI config:
<img width="586" alt="Screen Shot 2021-07-20 at 2 58 49 PM" src="https://user-images.githubusercontent.com/72415379/126400940-52a26ca5-f3e2-4946-992b-5139efd5baf0.png">

This field may be set to a comma-delimited list of host names that we'll allow requests from if said hostname appears in the URL of the request's referrer field. Setting the field to an empty string will disable the referrer check.

In the main module for the DOI API, all incoming requests are now checked to ensure the referrer field contains one of the valid host names. If there is a mismatch, or no referrer is specified at all, the request is denied and an HTTP error code is returned with the response:

<img width="1294" alt="Screen Shot 2021-07-20 at 3 04 05 PM" src="https://user-images.githubusercontent.com/72415379/126401463-6325bfc5-e23d-4135-8258-bfaf6f2f917a.png">

<img width="1313" alt="Screen Shot 2021-07-20 at 3 05 08 PM" src="https://user-images.githubusercontent.com/72415379/126401472-b1be2cc5-6dc8-4b10-8b51-edfde615130f.png">

<img width="1148" alt="Screen Shot 2021-07-20 at 3 05 50 PM" src="https://user-images.githubusercontent.com/72415379/126401479-4c5aa976-d373-4121-9925-c49ce192d16a.png">


Note that this has an unfortunate side-effect of hampering support for the built-in Swagger UI, since it does not seem to provide a referrer on its first request. If you plan to use the built-in UI, you should disable the referrer check by leaving the `api_valid_referrers` field empty.

**Test Data and/or Report**
Tests for the DOI API have been updated to include a valid referrer with each request. An additional test has also been added specific to the referrer check.
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/6851502/test.txt)


**Related Issues**
Resolves #228 
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
->