### PR TITLE
DOI API v0.2 Update

### DIFF
--- a/src/pds_doi_service/api/__main__.py
+++ b/src/pds_doi_service/api/__main__.py
@@ -73,17 +73,18 @@ def _check_referrer():
     logger = logging.getLogger(__name__)
     config = DOIConfigUtil().get_config()
 
-    valid_referrers = config.get('OTHER', 'api_valid_referrers')
-    valid_referrers = list(map(str.strip, valid_referrers.split(',')))
-    logger.debug("Valid referrers: %s", valid_referrers)
+    referrer = connexion.request.referrer
+    logger.debug("Referrer: %s", referrer)
+
+    valid_referrers = config.get('OTHER', 'api_valid_referrers', fallback=None)
 
     # if no valid referrers are configured, just return None to allow
     # request to go forward
     if not valid_referrers:
         return None
 
-    referrer = connexion.request.referrer
-    logger.debug("Referrer: %s", referrer)
+    valid_referrers = list(map(str.strip, valid_referrers.split(',')))
+    logger.debug("Valid referrers: %s", valid_referrers)
 
     if not referrer:
         raise InvalidReferrer('No referrer specified from request')

--- a/src/pds_doi_service/api/models/doi_record.py
+++ b/src/pds_doi_service/api/models/doi_record.py
@@ -12,7 +12,7 @@ class DoiRecord(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, doi: str = None, lidvid: str = None, title: str = None,
+    def __init__(self, doi: str = None, identifier: str = None, title: str = None,
                  node: str = None, submitter: str = None, status: str = None,
                  creation_date: datetime = None, update_date: datetime = None,
                  record: str = None, message: str = None):  # noqa: E501
@@ -20,8 +20,8 @@ class DoiRecord(Model):
 
         :param doi: The doi of this DoiRecord.  # noqa: E501
         :type doi: str
-        :param lidvid: The lidvid of this DoiRecord.  # noqa: E501
-        :type lidvid: str
+        :param identifier: The PDS identifier of this DoiRecord.  # noqa: E501
+        :type identifier: str
         :param title: The title of this DoiRecord.  # noqa: E501
         :type title: str
         :param node: The node of this DoiRecord.  # noqa: E501
@@ -41,7 +41,7 @@ class DoiRecord(Model):
         """
         self.swagger_types = {
             'doi': str,
-            'lidvid': str,
+            'identifier': str,
             'title': str,
             'node': str,
             'submitter': str,
@@ -54,7 +54,7 @@ class DoiRecord(Model):
 
         self.attribute_map = {
             'doi': 'doi',
-            'lidvid': 'lidvid',
+            'identifier': 'identifier',
             'title': 'title',
             'node': 'node',
             'submitter': 'submitter',
@@ -65,7 +65,7 @@ class DoiRecord(Model):
             'message': 'message'
         }
         self._doi = doi
-        self._lidvid = lidvid
+        self._identifier = identifier
         self._title = title
         self._node = node
         self._submitter = submitter
@@ -108,25 +108,25 @@ class DoiRecord(Model):
         self._doi = doi
 
     @property
-    def lidvid(self) -> str:
-        """Gets the lidvid of this DoiRecord.
+    def identifier(self) -> str:
+        """Gets the PDS identifier of this DoiRecord.
 
 
-        :return: The lidvid of this DoiRecord.
+        :return: The identifier of this DoiRecord.
         :rtype: str
         """
-        return self._lidvid
+        return self._identifier
 
-    @lidvid.setter
-    def lidvid(self, lidvid: str):
-        """Sets the lidvid of this DoiRecord.
+    @identifier.setter
+    def identifier(self, identifier: str):
+        """Sets the PDS identifier of this DoiRecord.
 
 
-        :param lidvid: The lidvid of this DoiRecord.
-        :type lidvid: str
+        :param identifier: The identifier of this DoiRecord.
+        :type identifier: str
         """
 
-        self._lidvid = lidvid
+        self._identifier = identifier
 
     @property
     def title(self) -> str:

--- a/src/pds_doi_service/api/models/doi_summary.py
+++ b/src/pds_doi_service/api/models/doi_summary.py
@@ -12,15 +12,15 @@ class DoiSummary(Model):
 
     Do not edit the class manually.
     """
-    def __init__(self, doi: str = None, lidvid: str = None, title: str = None,
+    def __init__(self, doi: str = None, identifier: str = None, title: str = None,
                  node: str = None, submitter: str = None, status: str = None,
                  update_date: datetime = None):  # noqa: E501
         """DoiSummary - a model defined in Swagger
 
         :param doi: The doi of this DoiSummary.  # noqa: E501
         :type doi: str
-        :param lidvid: The lidvid of this DoiSummary.  # noqa: E501
-        :type lidvid: str
+        :param identifier: The PDS identifier of this DoiSummary.  # noqa: E501
+        :type identifier: str
         :param title: The title of this DoiRecord.  # noqa: E501
         :type title: str
         :param node: The node of this DoiSummary.  # noqa: E501
@@ -34,7 +34,7 @@ class DoiSummary(Model):
         """
         self.swagger_types = {
             'doi': str,
-            'lidvid': str,
+            'identifier': str,
             'title': str,
             'node': str,
             'submitter': str,
@@ -44,7 +44,7 @@ class DoiSummary(Model):
 
         self.attribute_map = {
             'doi': 'doi',
-            'lidvid': 'lidvid',
+            'identifier': 'identifier',
             'title': 'title',
             'node': 'node',
             'submitter': 'submitter',
@@ -52,7 +52,7 @@ class DoiSummary(Model):
             'update_date': 'update_date'
         }
         self._doi = doi
-        self._lidvid = lidvid
+        self._identifier = identifier
         self._title = title
         self._node = node
         self._submitter = submitter
@@ -92,25 +92,25 @@ class DoiSummary(Model):
         self._doi = doi
 
     @property
-    def lidvid(self) -> str:
-        """Gets the lidvid of this DoiSummary.
+    def identifier(self) -> str:
+        """Gets the PDS identifier of this DoiSummary.
 
 
-        :return: The lidvid of this DoiSummary.
+        :return: The identifier of this DoiSummary.
         :rtype: str
         """
-        return self._lidvid
+        return self._identifier
 
-    @lidvid.setter
-    def lidvid(self, lidvid: str):
-        """Sets the lidvid of this DoiSummary.
+    @identifier.setter
+    def identifier(self, identifier: str):
+        """Sets the identifier of this DoiSummary.
 
 
-        :param lidvid: The lidvid of this DoiSummary.
-        :type lidvid: str
+        :param identifier: The identifier of this DoiSummary.
+        :type identifier: str
         """
 
-        self._lidvid = lidvid
+        self._identifier = identifier
 
     @property
     def title(self) -> str:

--- a/src/pds_doi_service/api/swagger/swagger.yaml
+++ b/src/pds_doi_service/api/swagger/swagger.yaml
@@ -1,12 +1,12 @@
 openapi: 3.0.0
 info:
   title: Planetary Data System DOI Service API
-  description: PDS API for managing DOI registration with OSTI service.
-  version: "0.1"
+  description: PDS API for managing DOI registration with a DOI service provider (OSTI, DataCite, etc.).
+  version: "0.2"
 servers:
-- url: http://localhost:8080/PDS_APIs/pds_doi_api/0.1
+- url: http://localhost:8080/PDS_APIs/pds_doi_api/0.2
   description: Local host
-- url: https://virtserver.swaggerhub.com/PDS_APIs/pds_doi_api/0.1
+- url: https://virtserver.swaggerhub.com/PDS_APIs/pds_doi_api/0.2
   description: SwaggerHub API Auto Mocking
 tags:
 - name: dois
@@ -66,10 +66,10 @@ paths:
           items:
             type: string
         example: review
-      - name: lid
+      - name: ids
         in: query
-        description: List of LIDs to filter DOIs by. An LID may include the VID appended
-          to the end. Each LID or LIDVID may also contain one or more Unix-style wildcards (*) to pattern match against.
+        description: List of PDS identifiers to filter DOIs by. Each identifier may
+          contain one or more Unix-style wildcards (*) to pattern match against.
         required: false
         style: form
         explode: true
@@ -78,34 +78,32 @@ paths:
           items:
             type: string
         examples:
-          lid:
-            value: 'urn:nasa:pds:lab_shocked_feldspars'
-          lidvid:
+          pds4:
             value: 'urn:nasa:pds:lab_shocked_feldspars::1.0'
+          pds3:
+            value: 'LRO-L-MRFLRO-2/3/5-BISTATIC-V3.0'
       - name: start_date
         in: query
         description: A start date to filter resulting DOI records by. Only records
-          with an update time after this date will be returned. Value must be of the
-          form \<YYYY\>-\<mm\>-\<dd\>T\<HH\>:\<MM\>:\<SS\>.\<ms\>
+          with an update time after this date will be returned. Value must be a
+          valid isoformat string of the form \<YYYY\>-\<mm\>-\<dd\>[T\<HH\>:\<MM\>:\<SS\>.\<ms\>]
         required: false
         style: form
         explode: true
         schema:
           type: string
-          format: date-time
-        example: 2020-01-01T19:02:15.000000
+        example: 2020-01-01T00:00:00.00
       - name: end_date
         in: query
         description: An end date to filter resulting DOI records by. Only records
-          with an update time prior to this date will be returned. Value must be of
-          the form \<YYYY\>-\<mm\>-\<dd\>T\<HH\>:\<SS\>.\<ms\>
+          with an update time prior to this date will be returned. Value must be a
+          valid isoformat string of the form \<YYYY\>-\<mm\>-\<dd\>[T\<HH\>:\<SS\>.\<ms\>]
         required: false
         style: form
         explode: true
         schema:
           type: string
-          format: date-time
-        example: 2020-12-311T23:59:00.000000
+        example: 2020-12-31T23:59:00.00
       responses:
         "200":
           description: Success
@@ -207,7 +205,7 @@ paths:
               example:
               - creation_date: 2021-03-09T00:00:00Z
                 doi: 10.17189/29476
-                lidvid: urn:nasa:pds:lab_shocked_feldspars::1.0
+                identifier: urn:nasa:pds:lab_shocked_feldspars::1.0
                 node: eng
                 record: |
                   <?xml version="1.0" encoding="UTF-8"?>
@@ -232,19 +230,24 @@ paths:
         "500":
           description: Internal error
       x-openapi-router-controller: pds_doi_service.api.controllers.dois_controller
-  /dois/{lidvid}:
+  /doi:
+    description: >-
+      Endpoint for submitting or fetching a single DOI record.
+      This endpoint corresponds to the /dois/{lidvid} endpoint of v0.1 of the API.
+      However, since certain lidvids were observed to contain forward slashes ('/'),
+      this version now expects the lidvid (now called identifier) as part of the query.
     get:
       tags:
       - dois
       description: Get the status of a DOI from the transaction database.
       operationId: get_doi_from_id
       parameters:
-      - name: lidvid
-        in: path
-        description: The LIDVID associated with the record to status or update.
+      - name: identifier
+        in: query
+        description: The PDS identifier associated with the record to fetch.
         required: true
-        style: simple
-        explode: false
+        style: form
+        explode: true
         schema:
           type: string
         example: 'urn:nasa:pds:lab_shocked_feldspars::1.0'
@@ -258,7 +261,7 @@ paths:
               example:
               - creation_date: 2021-03-09T00:00:00Z
                 doi: 10.17189/29476
-                lidvid: urn:nasa:pds:lab_shocked_feldspars::1.0
+                identifier: urn:nasa:pds:lab_shocked_feldspars::1.0
                 node: eng
                 record: |
                   <?xml version="1.0" encoding="UTF-8"?>
@@ -287,12 +290,12 @@ paths:
       description: Update the record associated with an existing DOI.
       operationId: put_doi_from_id
       parameters:
-      - name: lidvid
-        in: path
-        description: The LIDVID associated with the record to status or update.
+      - name: identifier
+        in: query
+        description: The PDS identifier associated with the record to update.
         required: true
-        style: simple
-        explode: false
+        style: form
+        explode: true
         schema:
           type: string
         example: 'urn:nasa:pds:lab_shocked_feldspars::1.0'
@@ -329,19 +332,24 @@ paths:
         "501":
           description: Not implemented
       x-openapi-router-controller: pds_doi_service.api.controllers.dois_controller
-  /dois/{lidvid}/submit:
+  /doi/submit:
+    description: >-
+      Endpoint for submitting a DOI record for review by the Engineering Node.
+      This endpoint corresponds to the /dois/{lidvid}/submit endpoint of v0.1 of the API.
+      However, since certain lidvids were observed to contain forward slashes ('/'),
+      this version now expects the lidvid (now called identifier) as part of the query.
     post:
       tags:
       - dois
       description: Move a DOI record from draft/reserve status to "review".
       operationId: post_submit_doi
       parameters:
-      - name: lidvid
-        in: path
-        description: The LIDVID associated with the record to submit for review.
+      - name: identifier
+        in: query
+        description: The PDS identifier associated with the record to submit for review.
         required: true
-        style: simple
-        explode: false
+        style: form
+        explode: true
         schema:
           type: string
         example: urn:nasa:pds:lab_shocked_feldspars::1.0
@@ -365,26 +373,26 @@ paths:
         "400":
           description: Can not be released
         "404":
-          description: No entry found for LIDVID
+          description: No entry found for identifier
         "500":
           description: Internal error
       x-openapi-router-controller: pds_doi_service.api.controllers.dois_controller
 # TODO: This routing endpoint has been commented out to effectively block access
 #       to the API's release endpoint until an authentication scheme can
 #       be incorporated to ensure only the Engineering node has access.
-#  /dois/{lidvid}/release:
+#  /doi/release:
 #    post:
 #      tags:
 #      - dois
 #      description: Move a DOI record from draft/reserve/review status to "release".
 #      operationId: post_release_doi
 #      parameters:
-#      - name: lidvid
+#      - name: identifier
 #        in: path
-#        description: The LIDVID associated with the record to release.
+#        description: The PDS identifier associated with the record to release.
 #        required: true
-#        style: simple
-#        explode: false
+#        style: form
+#        explode: true
 #        schema:
 #          type: string
 #        example: 'urn:nasa:pds:lab_shocked_feldspars::1.0'
@@ -408,7 +416,7 @@ paths:
 #        "400":
 #          description: Can not be released
 #        "404":
-#          description: No entry found for LIDVID
+#          description: No entry found for identifier
 #        "500":
 #          description: Internal error
 #      x-openapi-router-controller: pds_doi_service.api.controllers.dois_controller
@@ -490,7 +498,7 @@ components:
       properties:
         doi:
           type: string
-        lidvid:
+        identifier:
           type: string
         title:
           type: string
@@ -506,7 +514,7 @@ components:
       example:
         node: eng
         submitter: my.email@node.gov
-        lidvid: urn:nasa:pds:lab_shocked_feldspars::1.0
+        identifier: urn:nasa:pds:lab_shocked_feldspars::1.0
         title: Laboratory Shocked Feldspars Collection
         update_date: 2001-01-23T04:56:07.000+00:00
         doi: 10.17189/21734


### PR DESCRIPTION
**Summary**
This PR integrates the swagger definition for v0.2 of the DOI API into the controller code. v0.2 of the API was created to deal with the use `lidvid` as a path parameter to certain endpoints. Since certain lidvids could contain forward slashes, the corresponding endpoints would be unreachable. In the new spec, the `lidvid` token (now called simply called `identifier`) is included in the query section of the path, side-stepping the issue entirely.

This PR makes the necessary changes for the API controller (and associated regression tests) to meet the new spec. No new functionality has been added. Updates to bring the DOI service core library in-line with these changes will occur in a future PR.

**Test Data and/or Report**
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/6920005/test.txt)


**Related Issues**
Partially resolves #229 
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
->