### PR TITLE
DataCite Label Validator

### DIFF
--- a/src/pds_doi_service/core/actions/draft.py
+++ b/src/pds_doi_service/core/actions/draft.py
@@ -36,7 +36,7 @@ from pds_doi_service.core.input.input_util import DOIInputUtil
 from pds_doi_service.core.input.node_util import NodeUtil
 from pds_doi_service.core.outputs.doi_validator import DOIValidator
 from pds_doi_service.core.outputs.osti.osti_record import DOIOstiRecord
-from pds_doi_service.core.outputs.osti.osti_validator import OSTIValidator
+from pds_doi_service.core.outputs.osti.osti_validator import DOIOstiValidator
 from pds_doi_service.core.outputs.osti.osti_web_parser import DOIOstiWebParser
 from pds_doi_service.core.util.general_util import get_logger
 
@@ -55,7 +55,7 @@ class DOICoreActionDraft(DOICoreAction):
     def __init__(self, db_name=None):
         super().__init__(db_name=db_name)
         self._doi_validator = DOIValidator(db_name=db_name)
-        self._osti_validator = OSTIValidator()
+        self._osti_validator = DOIOstiValidator()
         self._list_obj = DOICoreActionList(db_name=db_name)
 
         self._input = None
@@ -318,7 +318,7 @@ class DOICoreActionDraft(DOICoreAction):
             )
 
             for doi_label in i_doi_labels:
-                self._osti_validator.validate(doi_label, action=self._name)
+                self._osti_validator.validate(doi_label)
 
             for doi_obj in doi_objs:
                 self._doi_validator.validate(doi_obj)

--- a/src/pds_doi_service/core/actions/release.py
+++ b/src/pds_doi_service/core/actions/release.py
@@ -29,7 +29,7 @@ from pds_doi_service.core.input.node_util import NodeUtil
 from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_JSON
 from pds_doi_service.core.outputs.doi_validator import DOIValidator
 from pds_doi_service.core.outputs.osti.osti_record import DOIOstiRecord
-from pds_doi_service.core.outputs.osti.osti_validator import OSTIValidator
+from pds_doi_service.core.outputs.osti.osti_validator import DOIOstiValidator
 from pds_doi_service.core.outputs.osti.osti_web_client import DOIOstiWebClient
 from pds_doi_service.core.util.general_util import get_logger
 
@@ -45,7 +45,7 @@ class DOICoreActionRelease(DOICoreAction):
     def __init__(self, db_name=None):
         super().__init__(db_name=db_name)
         self._doi_validator = DOIValidator(db_name=db_name)
-        self._osti_validator = OSTIValidator()
+        self._osti_validator = DOIOstiValidator()
         self._input_util = DOIInputUtil(valid_extensions=['.xml', '.json'])
 
         self._input = None
@@ -156,7 +156,7 @@ class DOICoreActionRelease(DOICoreAction):
                 single_doi_label = DOIOstiRecord().create_doi_record(doi)
 
                 # Validate XML representation of the DOI
-                self._osti_validator.validate(single_doi_label, action=self._name)
+                self._osti_validator.validate(single_doi_label)
 
                 # Validate the object representation of the DOI
                 self._doi_validator.validate(doi)

--- a/src/pds_doi_service/core/actions/reserve.py
+++ b/src/pds_doi_service/core/actions/reserve.py
@@ -29,7 +29,7 @@ from pds_doi_service.core.input.node_util import NodeUtil
 from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_JSON
 from pds_doi_service.core.outputs.doi_validator import DOIValidator
 from pds_doi_service.core.outputs.osti.osti_record import DOIOstiRecord
-from pds_doi_service.core.outputs.osti.osti_validator import OSTIValidator
+from pds_doi_service.core.outputs.osti.osti_validator import DOIOstiValidator
 from pds_doi_service.core.outputs.osti.osti_web_client import DOIOstiWebClient
 from pds_doi_service.core.util.general_util import get_logger
 
@@ -45,7 +45,7 @@ class DOICoreActionReserve(DOICoreAction):
     def __init__(self, db_name=None):
         super().__init__(db_name=db_name)
         self._doi_validator = DOIValidator(db_name=db_name)
-        self._osti_validator = OSTIValidator()
+        self._osti_validator = DOIOstiValidator()
         self._input_util = DOIInputUtil()
 
         self._input = None
@@ -154,7 +154,7 @@ class DOICoreActionReserve(DOICoreAction):
                 single_doi_label = DOIOstiRecord().create_doi_record(doi)
 
                 # Validate XML representation of the DOI
-                self._osti_validator.validate(single_doi_label, action=self._name)
+                self._osti_validator.validate(single_doi_label)
 
                 # Validate the object representation of the DOI
                 self._doi_validator.validate(doi)

--- a/src/pds_doi_service/core/input/input_util.py
+++ b/src/pds_doi_service/core/input/input_util.py
@@ -28,7 +28,7 @@ from lxml import etree
 from pds_doi_service.core.entities.doi import Doi, DoiStatus, ProductType
 from pds_doi_service.core.input.exceptions import InputFormatException
 from pds_doi_service.core.input.pds4_util import DOIPDS4LabelUtil
-from pds_doi_service.core.outputs.osti.osti_validator import OSTIValidator
+from pds_doi_service.core.outputs.osti.osti_validator import DOIOstiValidator
 from pds_doi_service.core.outputs.osti.osti_web_parser import (DOIOstiXmlWebParser,
                                                                DOIOstiJsonWebParser)
 from pds_doi_service.core.util.config_parser import DOIConfigUtil
@@ -128,7 +128,7 @@ class DOIInputUtil:
                         basename(xml_path))
 
             try:
-                OSTIValidator()._validate_against_xsd(xml_tree)
+                DOIOstiValidator()._validate_against_xsd(xml_tree)
 
                 dois, _ = DOIOstiXmlWebParser.parse_dois_from_label(xml_contents)
             except XMLSchemaValidationError as err:

--- a/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
+++ b/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
@@ -23,6 +23,16 @@
                 {% if doi.id %}
                 "suffix": "{{ doi.id }}",
                 {% endif %}
+                "identifiers": [
+                    {
+                        {% if doi.doi %}
+                        "identifier": "{{ doi.doi }}",
+                        {% else %}
+                        "identifier": "TBD",
+                        {% endif %}
+                        "identifierType": "DOI"
+                    }
+                ],
                 "creators": [
                     {% for author in doi.authors %}
                     {
@@ -93,7 +103,8 @@
                 "updated": "{{ doi.date_record_updated }}",
                 {% endif %}
                 "state": "{{ doi.status.value }}",
-                "language": "en"
+                "language": "en",
+                "schemaVersion": "http://datacite.org/schema/kernel-4"
             }
         }{% if not loop.last %},{% endif +%}
     {% endfor %}

--- a/src/pds_doi_service/core/outputs/datacite/__init__.py
+++ b/src/pds_doi_service/core/outputs/datacite/__init__.py
@@ -8,6 +8,7 @@ classes of the outputs package.
 """
 
 from .datacite_record import DOIDataCiteRecord
+from .datacite_validator import DOIDataCiteValidator
 from .datacite_web_client import DOIDataCiteWebClient
 from .datacite_web_parser import DOIDataCiteWebParser
 

--- a/src/pds_doi_service/core/outputs/datacite/datacite_4.3_schema.json
+++ b/src/pds_doi_service/core/outputs/datacite/datacite_4.3_schema.json
@@ -1,0 +1,490 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+
+    "definitions": {
+        "nameType": {
+            "type": "string",
+            "enum": [
+                "Organizational",
+                "Personal"
+            ]
+        },
+        "nameIdentifiers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "nameIdentifier": {"type": "string"},
+                    "nameIdentifierScheme": {"type": "string"},
+                    "schemeURI": {"type": "string", "format": "uri"}
+                },
+                "required": ["nameIdentifier", "nameIdentifierScheme"]
+            },
+            "uniqueItems": true
+        },
+        "affiliations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "affiliation": {"type": "string"}
+                },
+                "required": ["affiliation"]
+            },
+            "uniqueItems": true
+        },
+        "titleType": {
+            "type": "string",
+            "enum": [
+                "AlternativeTitle",
+                "Subtitle",
+                "TranslatedTitle",
+                "Other"
+            ]
+        },
+        "contributorType": {
+            "type": "string",
+            "enum": [
+                "ContactPerson",
+                "DataCollector",
+                "DataCurator",
+                "DataManager",
+                "Distributor",
+                "Editor",
+                "HostingInstitution",
+                "Producer",
+                "ProjectLeader",
+                "ProjectManager",
+                "ProjectMember",
+                "RegistrationAgency",
+                "RegistrationAuthority",
+                "RelatedPerson",
+                "Researcher",
+                "ResearchGroup",
+                "RightsHolder",
+                "Sponsor",
+                "Supervisor",
+                "WorkPackageLeader",
+                "Other"
+            ]
+        },
+        "date": {
+            "type": "string",
+            "anyOf": [
+                {"format": "year"},
+                {"format": "yearmonth"},
+                {"format": "date"},
+                {"format": "datetime"},
+                {"format": "year-range"},
+                {"format": "yearmonth-range"},
+                {"format": "date-range"},
+                {"format": "datetime-range"}
+            ]
+        },
+        "dateType": {
+            "type": "string",
+            "enum": [
+                "Accepted",
+                "Available",
+                "Copyrighted",
+                "Collected",
+                "Created",
+                "Issued",
+                "Submitted",
+                "Updated",
+                "Valid",
+                "Withdrawn",
+                "Other"
+            ]
+        },
+        "resourceTypeGeneral": {
+            "type": "string",
+            "enum": [
+                "Audiovisual",
+                "Collection",
+                "DataPaper",
+                "Dataset",
+                "Event",
+                "Image",
+                "InteractiveResource",
+                "Model",
+                "PhysicalObject",
+                "Service",
+                "Software",
+                "Sound",
+                "Text",
+                "Workflow",
+                "Other"
+            ]
+        },
+        "relatedIdentifierType": {
+            "type": "string",
+            "enum": [
+                "ARK",
+                "arXiv",
+                "bibcode",
+                "DOI",
+                "EAN13",
+                "EISSN",
+                "Handle",
+                "IGSN",
+                "ISBN",
+                "ISSN",
+                "ISTC",
+                "LISSN",
+                "LSID",
+                "PMID",
+                "PURL",
+                "UPC",
+                "URL",
+                "URN",
+                "w3id"
+            ]
+        },
+        "relationType": {
+            "type": "string",
+            "enum": [
+                "IsCitedBy",
+                "Cites",
+                "IsSupplementTo",
+                "IsSupplementedBy",
+                "IsContinuedBy",
+                "Continues",
+                "IsDescribedBy",
+                "Describes",
+                "HasMetadata",
+                "IsMetadataFor",
+                "HasVersion",
+                "IsVersionOf",
+                "IsNewVersionOf",
+                "IsPreviousVersionOf",
+                "IsPartOf",
+                "HasPart",
+                "IsReferencedBy",
+                "References",
+                "IsDocumentedBy",
+                "Documents",
+                "IsCompiledBy",
+                "Compiles",
+                "IsVariantFormOf",
+                "IsOriginalFormOf",
+                "IsIdenticalTo",
+                "IsReviewedBy",
+                "Reviews",
+                "IsDerivedFrom",
+                "IsSourceOf",
+                "IsRequiredBy",
+                "Requires",
+                "IsObsoletedBy",
+                "Obsoletes"
+            ]
+        },
+        "descriptionType": {
+            "type": "string",
+            "enum": [
+                "Abstract",
+                "Methods",
+                "SeriesInformation",
+                "TableOfContents",
+                "TechnicalInfo",
+                "Other"
+            ]
+        },
+        "geoLocationPoint": {
+            "type": "object",
+            "properties": {
+                "pointLongitude": {"$ref": "#/definitions/longitude"},
+                "pointLatitude": {"$ref": "#/definitions/latitude"}
+            },
+            "required": ["pointLongitude", "pointLatitude"]
+        },
+        "longitude": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180
+        },
+        "latitude": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90
+        },
+        "funderIdentifierType": {
+            "type": "string",
+            "enum": [
+                "ISNI",
+                "GRID",
+                "Crossref Funder ID",
+                "Other"
+            ]
+        }
+    },
+
+    "type": "object",
+
+    "properties": {
+        "types": {
+            "type": "object",
+            "properties": {
+                "resourceType": {"type": "string"},
+                "resourceTypeGeneral": {"$ref": "#/definitions/resourceTypeGeneral"}
+            },
+            "required": ["resourceType", "resourceTypeGeneral"]
+        },
+        "identifiers": {
+            "type": "array",
+            "items":{
+                "type": "object",
+                "properties": {
+                    "identifier": {"type": "string"},
+                    "identifierType": {"type": "string"}
+                },
+                "required": ["identifier", "identifierType"]
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "creators": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "nameType": {"$ref": "#/definitions/nameType"},
+                    "givenName": {"type": "string"},
+                    "familyName": {"type": "string"},
+                    "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
+                    "affiliations": {"$ref": "#/definitions/affiliations"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["name"]
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "titles": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "titleType": {"$ref": "#/definitions/titleType"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["title"]
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "publisher": {
+            "type": "string"
+        },
+        "publicationYear": {
+            "type": "string",
+            "format": "year"
+        },
+        "subjects": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "subject": {"type": "string"},
+                    "subjectScheme": {"type": "string"},
+                    "schemeURI": {"type": "string", "format": "uri"},
+                    "valueURI": {"type": "string", "format": "uri"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["subject"]
+            },
+            "uniqueItems": true
+        },
+        "contributors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "contributorType": {"$ref": "#/definitions/contributorType"},
+                    "name": {"type": "string"},
+                    "nameType": {"$ref": "#/definitions/nameType"},
+                    "givenName": {"type": "string"},
+                    "familyName": {"type": "string"},
+                    "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
+                    "affiliations": {"$ref": "#/definitions/affiliations"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["contributorType", "name"]
+            },
+            "uniqueItems": true
+        },
+        "dates": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "date": {"$ref": "#/definitions/date"},
+                    "dateType": {"$ref": "#/definitions/dateType"},
+                    "dateInformation": {"type": "string"}
+                },
+                "required": ["date", "dateType"]
+            },
+            "uniqueItems": true
+        },
+        "language": {
+            "type": "string",
+            "$comment": "Primary language of the resource. Allowed values are taken from  IETF BCP 47, ISO 639-1 language codes."
+        },
+        "alternateIdentifiers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "alternateIdentifier": {"type": "string"},
+                    "alternateIdentifierType": {"type": "string"}
+                },
+                "required": ["alternateIdentifier", "alternateIdentifierType"]
+            },
+            "uniqueItems": true
+        },
+        "relatedIdentifiers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "relatedIdentifier": {"type": "string"},
+                    "relatedIdentifierType": {"$ref": "#/definitions/relatedIdentifierType"},
+                    "relationType": {"$ref": "#/definitions/relationType"},
+                    "relatedMetadataScheme": {"type": "string"},
+                    "schemeURI": {"type": "string", "format": "uri"},
+                    "schemeType": {"type": "string"},
+                    "resourceTypeGeneral": {"$ref": "#/definitions/resourceTypeGeneral"}
+                },
+                "required": ["relatedIdentifier", "relatedIdentifierType", "relationType"],
+                "if": {
+                    "properties": {
+                        "relationType": {"enum": ["HasMetadata", "IsMetadataFor"]}
+                    }
+                },
+                "else": {
+                    "$comment": "these properties may only be used with relation types HasMetadata/IsMetadataFor",
+                    "properties": {
+                        "relatedMetadataScheme": false,
+                        "schemeURI": false,
+                        "schemeType": false
+                    }
+                }
+            },
+            "uniqueItems": true
+        },
+        "sizes": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "formats": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "version": {
+            "type": "string"
+        },
+        "rightsList": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "rights": {"type": "string"},
+                    "rightsURI": {"type": "string", "format": "uri"},
+                    "rightsIdentifier": {"type": "string"},
+                    "rightsIdentifierScheme": {"type": "string"},
+                    "schemeURI": {"type": "string", "format": "uri"},
+                    "lang": {"type": "string"}
+                }
+            },
+            "uniqueItems": true
+        },
+        "descriptions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "description": {"type": "string"},
+                    "descriptionType": {"$ref": "#/definitions/descriptionType"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["description", "descriptionType"]
+            },
+            "uniqueItems": true
+        },
+        "geoLocations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "geoLocationPlace": {"type": "string"},
+                    "geoLocationPoint": {"$ref": "#/definitions/geoLocationPoint"},
+                    "geoLocationBox": {
+                        "type": "object",
+                        "properties": {
+                            "westBoundLongitude": {"$ref": "#/definitions/longitude"},
+                            "eastBoundLongitude": {"$ref": "#/definitions/longitude"},
+                            "southBoundLatitude": {"$ref": "#/definitions/latitude"},
+                            "northBoundLatitude": {"$ref": "#/definitions/latitude"}
+                        },
+                        "required": ["westBoundLongitude", "eastBoundLongitude", "southBoundLatitude", "northBoundLatitude"]
+                    },
+                    "geoLocationPolygons": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "polygonPoints": {
+                                    "type": "array",
+                                    "items": {"$ref": "#/definitions/geoLocationPoint"},
+                                    "minItems": 4
+                                },
+                                "inPolygonPoint": {"$ref": "#/definitions/geoLocationPoint"}
+                            },
+                            "required": ["polygonPoints"]
+                        },
+                        "uniqueItems": true
+                    }
+                }
+            },
+            "uniqueItems": true
+        },
+        "fundingReferences": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "funderName": {"type": "string"},
+                    "funderIdentifier": {"type": "string"},
+                    "funderIdentifierType": {"$ref": "#/definitions/funderIdentifierType"},
+                    "awardNumber": {"type": "string"},
+                    "awardURI": {"type": "string", "format": "uri"},
+                    "awardTitle": {"type": "string"}
+                },
+                "required": ["funderName"]
+            },
+            "uniqueItems": true
+        },
+        "schemaVersion": {
+            "type": "string",
+            "const": "http://datacite.org/schema/kernel-4"
+        }
+    },
+
+    "required": [
+        "identifiers",
+        "creators",
+        "titles",
+        "publisher",
+        "publicationYear",
+        "types",
+        "schemaVersion"
+    ]
+}

--- a/src/pds_doi_service/core/outputs/datacite/datacite_validator.py
+++ b/src/pds_doi_service/core/outputs/datacite/datacite_validator.py
@@ -1,0 +1,97 @@
+#
+#  Copyright 2021, by the California Institute of Technology.  ALL RIGHTS
+#  RESERVED. United States Government Sponsorship acknowledged. Any commercial
+#  use must be negotiated with the Office of Technology Transfer at the
+#  California Institute of Technology.
+#
+
+"""
+=====================
+datacite_validator.py
+=====================
+
+Contains functions for validating the contents of DataCite JSON labels.
+"""
+
+import json
+from os.path import exists
+
+import jsonschema
+from distutils.util import strtobool
+from pkg_resources import resource_filename
+
+from pds_doi_service.core.input.exceptions import InputFormatException
+from pds_doi_service.core.outputs.service_validator import DOIServiceValidator
+from pds_doi_service.core.util.general_util import get_logger
+
+logger = get_logger(__name__)
+
+
+class DOIDataCiteValidator(DOIServiceValidator):
+    """
+    DataCiteValidator provides methods to validate JSON labels submitted to
+    DataCite to ensure compliance with their expected format.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        schema_file = resource_filename(__name__, 'datacite_4.3_schema.json')
+
+        if not exists(schema_file):
+            raise RuntimeError(
+                'Could not find the schema file needed by this module.\n'
+                f'Expected schema file: {schema_file}'
+            )
+
+        with open(schema_file, 'r') as infile:
+            schema = json.load(infile)
+
+        try:
+            jsonschema.Draft7Validator.check_schema(schema)
+        except jsonschema.exceptions.SchemaError as err:
+            raise RuntimeError(
+                f'Schema file {schema_file} is not a valid JSON schema, '
+                f'reason: {err}'
+            )
+
+        self._schema_validator = jsonschema.Draft7Validator(schema)
+
+    def validate(self, label_contents):
+        """
+        Validates contents of a DataCite JSON label against their JSON schema
+        to ensure compliance prior to submission.
+
+        Parameters
+        ----------
+        label_contents : str
+            Contents of the DataCite JSON label.
+
+        Raises
+        ------
+        InputFormatException
+            If the provided label text fails schema validation.
+
+        """
+        validate_against_schema = self._config.get(
+            'DATACITE', 'validate_against_schema', fallback='False'
+        )
+
+        # Check the label contents against the DataCite JSON schema
+        if strtobool(validate_against_schema):
+            json_contents = json.loads(label_contents)
+
+            if 'data' in json_contents and 'attributes' in json_contents['data']:
+                # Strip off the stuff that is not covered by the JSON schema
+                json_contents = json_contents['data']['attributes']
+
+            if not self._schema_validator.is_valid(json_contents):
+                error_message = 'Provided JSON does not conform to the DataCite Schema, reason(s):\n'
+
+                for error in self._schema_validator.iter_errors(json_contents):
+                    error_message += '{path}: {message}\n'.format(
+                        path='/'.join(map(str, error.path)),
+                        message=error.message
+                    )
+
+                raise InputFormatException(error_message)

--- a/src/pds_doi_service/core/outputs/osti/__init__.py
+++ b/src/pds_doi_service/core/outputs/osti/__init__.py
@@ -8,5 +8,8 @@ classes of the outputs package.
 """
 
 from .osti_record import DOIOstiRecord
+from .osti_validator import DOIOstiValidator
 from .osti_web_client import DOIOstiWebClient
-from .osti_web_parser import DOIOstiJsonWebParser, DOIOstiXmlWebParser
+from .osti_web_parser import (DOIOstiWebParser,
+                              DOIOstiJsonWebParser,
+                              DOIOstiXmlWebParser)

--- a/src/pds_doi_service/core/outputs/service_validator.py
+++ b/src/pds_doi_service/core/outputs/service_validator.py
@@ -1,0 +1,42 @@
+#
+#  Copyright 2020-21, by the California Institute of Technology.  ALL RIGHTS
+#  RESERVED. United States Government Sponsorship acknowledged. Any commercial
+#  use must be negotiated with the Office of Technology Transfer at the
+#  California Institute of Technology.
+#
+
+"""
+====================
+service_validator.py
+====================
+
+Contains the base class for creating service-specific validator objects.
+"""
+
+from pds_doi_service.core.util.config_parser import DOIConfigUtil
+
+
+class DOIServiceValidator:
+    """
+    Abstract base class for performing service-specific validation of output
+    label formats. Validation is typically schema-based.
+    """
+
+    def __init__(self):
+        self._config = DOIConfigUtil.get_config()
+
+    def validate(self, label_contents):
+        """
+        Validates the provided output label contents against one or more
+        schemas utilized by the ServiceValidator instance.
+
+        Parameters
+        ----------
+        label_contents : str
+            Contents of the output label file to validate.
+
+        """
+        raise NotImplementedError(
+            f'Subclasses of {self.__class__.__name__} must provide an '
+            f'implementation for validate()'
+        )

--- a/src/pds_doi_service/core/util/conf.ini.default
+++ b/src/pds_doi_service/core/util/conf.ini.default
@@ -4,6 +4,7 @@ url = https://www.osti.gov/iad2test/api/records
 user = username
 password = secret
 doi_prefix = 10.17189
+validate_against_schema = True
 
 [DATACITE]
 url = https://api.test.datacite.org/dois
@@ -11,6 +12,7 @@ url = https://api.test.datacite.org/dois
 user = username
 password = secret
 doi_prefix = 10.13143
+validate_against_schema = True
 
 [PDS4_DICTIONARY]
 url = https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_JSON_1D00.JSON
@@ -24,6 +26,7 @@ pds_node_identifier = 0001_NASA_PDS_1.pds.Node.pds.name
 url = https://pds.nasa.gov/ds-view/pds/view{}.jsp?identifier={}&version={}
 
 [OTHER]
+logging_level = DEBUG
 doi_publisher = NASA Planetary Data System
 global_keyword_values = PDS; PDS4;
 pds_uri = http://pds.nasa.gov/pds4/pds/v1
@@ -37,7 +40,3 @@ emailer_local_host = localhost
 emailer_port       = 25
 emailer_sender     = pdsen-doi-test@jpl.nasa.gov
 emailer_receivers  = pdsen-doi-test@jpl.nasa.gov
-draft_validate_against_xsd_flag = True
-release_validate_against_xsd_flag = True
-reserve_validate_against_xsd_flag = True
-logging_level=DEBUG


### PR DESCRIPTION
**Summary**
This PR adds to the PDS DOI service the capability to validate DataCite-format JSON labels against their JSON schema prior to submission. This feature is required to have parity with the feature set currently available for OSTI.

**Test Data and/or Report**
Unit tests have been added for the new validation capability
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/7034542/test.txt)

**Related Issues**
Resolves #236 
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
->