### PR TITLE
DataCite Sync Script Update

### DIFF
--- a/src/pds_doi_service/core/actions/release.py
+++ b/src/pds_doi_service/core/actions/release.py
@@ -14,7 +14,7 @@ Contains the definition for the Release action of the Core PDS DOI Service.
 """
 
 from pds_doi_service.core.actions.action import DOICoreAction
-from pds_doi_service.core.entities.doi import DoiStatus
+from pds_doi_service.core.entities.doi import DoiEvent, DoiStatus
 from pds_doi_service.core.input.exceptions import (InputFormatException,
                                                    DuplicatedTitleDOIException,
                                                    UnexpectedDOIActionException,
@@ -136,6 +136,11 @@ class DOICoreActionRelease(DOICoreAction):
 
             # Add 'status' field so the ranking in the workflow can be determined.
             doi.status = DoiStatus.Pending if self._no_review else DoiStatus.Review
+
+            if self._no_review:
+                # Add the event field to instruct DataCite to publish DOI to
+                # findable state (should have no effect for other providers)
+                doi.event = DoiEvent.Publish
 
         return dois
 

--- a/src/pds_doi_service/core/entities/doi.py
+++ b/src/pds_doi_service/core/entities/doi.py
@@ -75,6 +75,26 @@ class DoiStatus(str, Enum):
     Deactivated = 'deactivated'
 
 
+@unique
+class DoiEvent(str, Enum):
+    """
+    Enumerates the possible DOI events that can be requested in a submission
+    to DataCite.
+
+    Events consist of:
+        Publish -
+            Moves a DOI from draft or registered state to findable
+        Register -
+            Moves a DOI from draft to registered
+        Hide -
+            Moves a DOI from findable back to registered
+
+    """
+    Publish = 'publish'
+    Register = 'register'
+    Hide = 'hide'
+
+
 @dataclass
 class Doi:
     """The dataclass definition for a Doi object."""
@@ -97,3 +117,4 @@ class Doi:
     message: str = None
     date_record_added: datetime = None
     date_record_updated: datetime = None
+    event: DoiEvent = None

--- a/src/pds_doi_service/core/entities/doi.py
+++ b/src/pds_doi_service/core/entities/doi.py
@@ -25,6 +25,7 @@ class ProductType(str, Enum):
     Bundle = 'Bundle'
     Text = 'Text'
     Dataset = 'Dataset'
+    Other = 'Other'
 
 
 @unique

--- a/src/pds_doi_service/core/entities/doi.py
+++ b/src/pds_doi_service/core/entities/doi.py
@@ -103,6 +103,7 @@ class Doi:
     product_type: ProductType
     product_type_specific: str
     related_identifier: str
+    identifiers: list = field(default_factory=list)
     authors: list = None
     keywords: set = field(default_factory=set)
     editors: list = None

--- a/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
+++ b/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
@@ -10,10 +10,8 @@
             {% endif %}
             "type": "dois",
             "attributes": {
-                {% if doi.status.value == "pending" %}
-                "event": "publish",
-                {% elif doi.status.value == "findable" %}
-                "event": "hide",
+                {% if doi.event %}
+                "event": "{{ doi.event.value }}",
                 {% endif %}
                 {% if doi.doi %}
                 "doi": "{{ doi.doi }}",
@@ -24,6 +22,12 @@
                 "suffix": "{{ doi.id }}",
                 {% endif %}
                 "identifiers": [
+                    {% for identifier in doi.identifiers %}
+                    {
+                        "identifier": "{{ identifier.identifier.strip() }}",
+                        "identifierType": "{{ identifier.identifierType }}"
+                    },
+                    {% endfor %}
                     {
                         {% if doi.doi %}
                         "identifier": "{{ doi.doi }}",
@@ -36,10 +40,25 @@
                 "creators": [
                     {% for author in doi.authors %}
                     {
+                        {% if author.name_type %}
+                        "nameType": "{{author.name_type}}",
+                        {% else %}
                         "nameType": "Personal",
-                        "name": "{{ author['last_name'] }}, {{ author['first_name'] }}",
-                        "givenName": "{{ author['first_name'] }}",
-                        "familyName": "{{ author['last_name'] }}"
+                        {% endif %}
+                        {% if author.first_name and author.last_name %}
+                        "name": "{{ author.first_name }} {{ author.last_name }}",
+                        {% else %}
+                        "name": "{{ author.name }}",
+                        {% endif %}
+                        "nameIdentifiers": [
+                        {% for name_identifier in author.name_identifiers %}
+                            {
+                            {% for key, value in name_identifier.items() %}
+                                "{{key}}": "{{value}}"{% if not loop.last %},{% endif +%}
+                            {% endfor %}
+                            }
+                        {% endfor %}
+                        ]
                     }{% if not loop.last %},{% endif +%}
                     {% endfor %}
                 ],
@@ -60,9 +79,20 @@
                     {% for editor in doi.editors %}
                     {
                         "nameType": "Personal",
-                        "name": "{{ editor['last_name'] }}, {{ editor['first_name'] }}",
-                        "givenName": "{{ editor['first_name'] }}",
-                        "familyName": "{{ editor['last_name'] }}",
+                        {% if editor.first_name and editor.last_name %}
+                        "name": "{{ editor.first_name }} {{ editor.last_name }}",
+                        {% else %}
+                        "name": "{{ editor.name }}",
+                        {% endif %}
+                        "nameIdentifiers": [
+                        {% for name_identifier in editor.name_identifiers %}
+                            {
+                            {% for key, value in name_identifier.items() %}
+                                "{{key}}": "{{value}}"{% if not loop.last %},{% endif +%}
+                            {% endfor %}
+                            }
+                        {% endfor %}
+                        ],
                         "contributorType": "Editor"
                     },
                     {% endfor %}
@@ -79,9 +109,8 @@
                 "relatedIdentifiers": [
                     {
                         "relatedIdentifier": "{{ doi.related_identifier }}",
-                        "relatedIdentifierType": "URN",
-                        "relationType": "HasMetadata",
-                        "resourceTypeGeneral": "Text"
+                        "relatedIdentifierType": {% if doi.related_identifier.lower().startswith("urn") %}"URN"{% else %}"Handle"{% endif %},
+                        "relationType": "IsIdenticalTo"
                     }
                 ],
                 {% if doi.description %}

--- a/src/pds_doi_service/core/outputs/datacite/datacite_web_client.py
+++ b/src/pds_doi_service/core/outputs/datacite/datacite_web_client.py
@@ -100,9 +100,9 @@ class DOIDataCiteWebClient(DOIWebClient):
 
         Notes
         -----
-        Queries are automatically filtered by this method to only include
-        DOI entries associated with the PDS client ID, which corresponds to the
-        username used with the query request.
+        Queries are NOT automatically filtered by this method. Callers should be
+        prepared to filter results as desired if more results are returned
+        by their query than expected.
 
         Parameters
         ----------
@@ -151,15 +151,13 @@ class DOIDataCiteWebClient(DOIWebClient):
             query_string = str(query)
 
         url = url or config.get('DATACITE', 'url')
-        client_id = (username or config.get('DATACITE', 'user')).lower()
 
         logger.debug('query_string: %s', query_string)
         logger.debug('url: %s', url)
-        logger.debug('client_id: %s', client_id)
 
         datacite_response = requests.request(
             WEB_METHOD_GET, url=url, auth=auth, headers=headers,
-            params={"query": query_string, "client-id": client_id}
+            params={"query": query_string}
         )
 
         try:

--- a/src/pds_doi_service/core/outputs/doi_validator.py
+++ b/src/pds_doi_service/core/outputs/doi_validator.py
@@ -43,12 +43,16 @@ class DOIValidator:
 
     # The workflow_order dictionary contains the progression of the status of a DOI:
     m_workflow_order = {
+        DoiStatus.Error: 0,
+        DoiStatus.Unknown: 0,
         DoiStatus.Reserved_not_submitted: 0,
         DoiStatus.Reserved: 1,
         DoiStatus.Draft: 2,
         DoiStatus.Review: 3,
         DoiStatus.Pending: 4,
-        DoiStatus.Registered: 5
+        DoiStatus.Registered: 5,
+        DoiStatus.Findable: 5,
+        DoiStatus.Deactivated: 5
     }
 
     def __init__(self, db_name=None):

--- a/src/pds_doi_service/core/outputs/service.py
+++ b/src/pds_doi_service/core/outputs/service.py
@@ -77,6 +77,31 @@ class DOIServiceFactory:
     _config = DOIConfigUtil().get_config()
 
     @staticmethod
+    def _check_service_type(service_type):
+        """
+        Checks if the provided service type is among the expected values.
+
+        Parameters
+        ----------
+        service_type : str
+            Service type to check. Is automatically converted to lowercase
+            to provide a case-insensitive check.
+
+        Raises
+        ------
+        ValueError
+            If the service type is not among the valid types recognized by this
+            class (or if no type is specified by the INI config at all).
+
+        """
+        if service_type.lower() not in VALID_SERVICE_TYPES:
+            raise ValueError(
+                f'Unsupported service type "{service_type}" provided.\n'
+                f'Service type should be assigned to the SERVICE.provider field of '
+                f'the INI config with one of the following values: {VALID_SERVICE_TYPES}'
+            )
+
+    @staticmethod
     def get_service_type():
         """
         Returns the configured service type as defined within the INI config.
@@ -87,30 +112,23 @@ class DOIServiceFactory:
             The service type to be used. This value is converted to lowercase
             by this method before it is returned.
 
-        Raises
-        ------
-        ValueError
-            If the service type is not among the valid types recognized by this
-            class (or if no type is specified by the INI config at all).
-
         """
         service_type = DOIServiceFactory._config.get(
             'SERVICE', 'provider', fallback='unassigned'
         )
 
-        if service_type.lower() not in VALID_SERVICE_TYPES:
-            raise ValueError(
-                f'Unsupported service type "{service_type}" provided.\n'
-                f'Service type must be assigned to the SERVICE.provider field of '
-                f'the INI config with one of the following values: {VALID_SERVICE_TYPES}'
-            )
-
         return service_type.lower()
 
     @staticmethod
-    def get_doi_record_service():
+    def get_doi_record_service(service_type=None):
         """
         Returns the appropriate DOIRecord subclass for the current service type.
+
+        Parameters
+        ----------
+        service_type : str, optional
+            The service type to return a DOIRecord subclass for. Defaults to
+            the SERVICE.provider value of the INI config.
 
         Returns
         -------
@@ -119,7 +137,10 @@ class DOIServiceFactory:
             DOI service type.
 
         """
-        service_type = DOIServiceFactory.get_service_type()
+        if not service_type:
+            service_type = DOIServiceFactory.get_service_type()
+
+        DOIServiceFactory._check_service_type(service_type)
 
         doi_record_class = DOIServiceFactory._DOI_RECORD_MAP[service_type]
         logger.debug('Returning instance of %s for service type %s',
@@ -128,9 +149,15 @@ class DOIServiceFactory:
         return doi_record_class()
 
     @staticmethod
-    def get_validator_service():
+    def get_validator_service(service_type=None):
         """
         Returns the appropriate DOIValidator subclass for the current service type.
+
+        Parameters
+        ----------
+        service_type : str, optional
+            The service type to return a DOIValidator subclass for. Defaults to
+            the SERVICE.provider value of the INI config.
 
         Returns
         -------
@@ -139,7 +166,10 @@ class DOIServiceFactory:
             DOI service type.
 
         """
-        service_type = DOIServiceFactory.get_service_type()
+        if not service_type:
+            service_type = DOIServiceFactory.get_service_type()
+
+        DOIServiceFactory._check_service_type(service_type)
 
         doi_validator_class = DOIServiceFactory._SERVICE_VALIDATOR_MAP[service_type]
         logger.debug('Returning instance of %s for service type %s',
@@ -148,9 +178,15 @@ class DOIServiceFactory:
         return doi_validator_class()
 
     @staticmethod
-    def get_web_client_service():
+    def get_web_client_service(service_type=None):
         """
         Returns the appropriate DOIWebClient subclass for the current service type.
+
+        Parameters
+        ----------
+        service_type : str, optional
+            The service type to return a DOIWebClient subclass for. Defaults to
+            the SERVICE.provider value of the INI config.
 
         Returns
         -------
@@ -159,7 +195,10 @@ class DOIServiceFactory:
             DOI service type.
 
         """
-        service_type = DOIServiceFactory.get_service_type()
+        if not service_type:
+            service_type = DOIServiceFactory.get_service_type()
+
+        DOIServiceFactory._check_service_type(service_type)
 
         web_client_class = DOIServiceFactory._WEB_CLIENT_MAP[service_type]
         logger.debug('Returning instance of %s for service type %s',
@@ -168,9 +207,15 @@ class DOIServiceFactory:
         return web_client_class()
 
     @staticmethod
-    def get_web_parser_service():
+    def get_web_parser_service(service_type=None):
         """
         Returns the appropriate DOIWebParser subclass for the current service type.
+
+        Parameters
+        ----------
+        service_type : str, optional
+            The service type to return a DOIWebParser subclass for. Defaults to
+            the SERVICE.provider value of the INI config.
 
         Returns
         -------
@@ -179,7 +224,10 @@ class DOIServiceFactory:
             DOI service type.
 
         """
-        service_type = DOIServiceFactory.get_service_type()
+        if not service_type:
+            service_type = DOIServiceFactory.get_service_type()
+
+        DOIServiceFactory._check_service_type(service_type)
 
         web_parser_class = DOIServiceFactory._WEB_PARSER_MAP[service_type]
         logger.debug('Returning instance of %s for service type %s',

--- a/src/pds_doi_service/core/outputs/web_parser.py
+++ b/src/pds_doi_service/core/outputs/web_parser.py
@@ -40,16 +40,20 @@ class DOIWebParser:
 
         """
         # TODO: rewrite to utilize urlparse and support PDS3 labels
+        lid_vid_value = None
+
         site_tokens = site_url.split("identifier=")
 
         identifier_tokens = site_tokens[1].split(";")
 
         lid_vid_tokens = identifier_tokens[0].split("&version=")
-        lid_value = lid_vid_tokens[0].replace("%3A", ":")
-        vid_value = lid_vid_tokens[1]
 
-        # Finally combine the lid and vid together.
-        lid_vid_value = lid_value + '::' + vid_value
+        if len(lid_vid_tokens) >= 2:
+            lid_value = lid_vid_tokens[0].replace("%3A", ":")
+            vid_value = lid_vid_tokens[1]
+
+            # Finally combine the lid and vid together.
+            lid_vid_value = lid_value + '::' + vid_value
 
         return lid_vid_value
 

--- a/src/pds_doi_service/core/util/general_util.py
+++ b/src/pds_doi_service/core/util/general_util.py
@@ -13,9 +13,32 @@ general_util.py
 General utility functions for things like logging.
 """
 
+import re
 import logging
 
 from pds_doi_service.core.util.config_parser import DOIConfigUtil
+
+
+def sanitize_json_string(string):
+    """
+    Cleans up extraneous whitespace from the provided string so it may be
+    written to a JSON file. Extraneous whitespace include any before or after
+    the provided string, as well as between words.
+
+    Parameters
+    ----------
+    string : str
+        The string to sanitize.
+
+    Returns
+    -------
+    string : str
+        The provided string, sanitized of extraneous whitespace.
+
+    """
+    # Clean up whitespace (including line breaks) both between words and
+    # at the ends of the string
+    return re.sub(r"\s+", " ", string, flags=re.UNICODE).strip()
 
 
 def get_logger(module_name=''):
@@ -34,6 +57,5 @@ def get_logger(module_name=''):
     logger.setLevel(getattr(logging, logging_level.upper()))
 
     return logger
-
 
 

--- a/src/pds_doi_service/core/util/initialize_production_deployment.py
+++ b/src/pds_doi_service/core/util/initialize_production_deployment.py
@@ -11,18 +11,24 @@
 initialize_production_deployment.py
 ===================================
 
-Script used to import the available DOIs from the server provider into a local
+Script used to import the available DOIs from a service provider into the local
 production database.
 """
 
 # Parameters to this script:
 #
+#    The -S (optional) is the name of the DOI service provider to pull existing
+#        DOI records from. When used with the -i option, it should correspond
+#        to the format of the provided input file. Should be set to either osti
+#        or datacite.
+#    The -p (optional) may be used to specify a DOI prefix to query for. By
+#    default the prefix is obtained from the INI config.
 #    The -s (required) is email of the PDS operator: -s pds-operator@jpl.nasa.gov
 #    The -i is optional. If the input is provided and is a file, parse from it
 #        The format of input file is the same format of text returned from
 #        querying the server via a browser or curl command.
 #        If provided,, this will override the url in the config file.
-#    The -d is optional.  If provided it is the name of the database file to
+#    The -d is optional. If provided it is the name of the database file to
 #    write records to: -d doi.db
 #        If provided, this will override the db_name in the config file.
 #    The --dry-run parameter allows the code to parse the input or querying the
@@ -56,13 +62,16 @@ production database.
 #       with the NASA-PDS account.
 
 import argparse
+import json
 import logging
 import os
 from datetime import datetime
 
 from pds_doi_service.core.input.exceptions import (InputFormatException,
                                                    CriticalDOIException)
-from pds_doi_service.core.outputs.service import DOIServiceFactory
+from pds_doi_service.core.outputs.service import (DOIServiceFactory,
+                                                  SERVICE_TYPE_DATACITE,
+                                                  VALID_SERVICE_TYPES)
 from pds_doi_service.core.outputs.osti.osti_web_parser import DOIOstiXmlWebParser
 from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_JSON
 from pds_doi_service.core.outputs.transaction_builder import TransactionBuilder
@@ -80,13 +89,26 @@ m_config = m_doi_config_util.get_config()
 def create_cmd_parser():
     parser = argparse.ArgumentParser(
         description='Script to bulk import existing DOIs into the local '
-                    'transaction database.'
+                    'transaction database.',
+        epilog='Note: When DOI records are imported to the local transaction '
+               'database, the DOI service creates an associated output label '
+               'for each record under the transaction_history directory. The '
+               'format of this output label is driven by the SERVICE.provider '
+               'field of the INI. Please ensure the field is set appropriately '
+               'before using this script, as a mismatch could cause parsing '
+               'errors when using the DOI service after this script.'
     )
-    parser.add_argument("-i", "--input", required=False,
-                        help="Input file (XML or JSON) to import existing DOIs from. "
-                             "If no value is provided, the server URL "
-                             "specified by the DOI service configuration INI "
-                             "file is used by default.")
+    parser.add_argument("-S", "--service", required=False, default=None,
+                        help="Name of the service provider to pull existing DOI "
+                             "records from. If not provided, the provider configured "
+                             "by the DOI service configuration INI is used by "
+                             "default. Should be one of: [{}]"
+                             .format(", ".join(VALID_SERVICE_TYPES)))
+    parser.add_argument("-p", "--prefix", required=False, default=None,
+                        help="Specify the DOI prefix value to query the service "
+                             "provider for. If not provided, the prefix value "
+                             "configured to the providing in the INI config is "
+                             "used by default.")
     parser.add_argument("-s", "--submitter-email", required=False,
                         default='pds-operator@jpl.nasa.gov',
                         help="The email address of the user performing the "
@@ -96,6 +118,11 @@ def create_cmd_parser():
                         help="Name of the SQLite3 database file name to commit "
                              "DOI records to. If not provided, the file name is "
                              "obtained from the DOI service INI config.")
+    parser.add_argument("-i", "--input-file", required=False,
+                        help="Input file (XML or JSON) to import existing DOIs from. "
+                             "If no value is provided, the server URL "
+                             "specified by the DOI service configuration INI "
+                             "file is used by default.")
     parser.add_argument("-o", "--output-file", required=False, default=None,
                         help="Path to write out the DOI JSON labels as returned "
                              "from the query. When created, this file can be used "
@@ -112,7 +139,23 @@ def create_cmd_parser():
 
 
 def _read_from_local_xml(path):
-    """Read from a local xml file containing output from a query."""
+    """
+    Read from a local xml file containing output from a query.
+
+    Note that since the PDS DOI service only supports XML labels from OSTI,
+    that is the default parser used by this function.
+
+    Parameters
+    ----------
+    path : str
+        Path of the XML file to read and parse.
+
+    Returns
+    -------
+    dois : list of Doi
+        The DOI objects parsed from the XML label.
+
+    """
     try:
         with open(path, mode='r') as f:
             doi_xml = f.read()
@@ -124,73 +167,139 @@ def _read_from_local_xml(path):
     return dois
 
 
-def _read_from_local_json(path):
-    """Read from a local JSON file containing output from a query."""
+def _read_from_local_json(service, path):
+    """
+    Read from a local JSON file containing output from a query.
+
+    The appropriate JSON parser (OSTI or DataCite) is determined based on
+    the provided service type.
+
+    Parameters
+    ----------
+    service : str
+        The name of the service provider corresponding to the JSON format
+        to read and parse.
+    path : str
+        Path to the JSON file to read and parse.
+
+    Returns
+    -------
+    dois : list of Doi
+        The DOI objects parsed from the JSON label.
+
+    """
     try:
         with open(path, mode='r') as f:
             doi_json = f.read()
     except Exception as e:
         raise CriticalDOIException(str(e))
 
-    web_parser = DOIServiceFactory.get_web_parser_service()
+    web_parser = DOIServiceFactory.get_web_parser_service(service)
 
-    dois, _ = web_parser.parse_dois_from_label(
-        doi_json, content_type=CONTENT_TYPE_JSON
-    )
+    try:
+        dois, _ = web_parser.parse_dois_from_label(
+            doi_json, content_type=CONTENT_TYPE_JSON
+        )
+    except Exception:
+        raise InputFormatException(
+            f"Unable to parse input file {path} using parser {web_parser.__name__}\n"
+            f"Please ensure the --service flag is set correctly to specify the "
+            f"correct parser type for the format."
+        )
 
     return dois
 
 
-def _read_from_path(path):
+def _read_from_path(service, path):
+    """
+    Reads the label at the provided path, using the appropriate parser for the
+    provided service type.
+
+    Parameters
+    ----------
+    service : str
+        The name of the service provider corresponding to the format
+        to read and parse. Only used for JSON labels.
+    path : str
+        Path to the label to read and parse. The label format (XML or JSON) is
+        derived from the path's file extension.
+
+    Returns
+    -------
+    dois : list of Doi
+        The DOI objects parsed from the label.
+
+    Raises
+    ------
+    InputFormatException
+        If the file path does not exist or does not correspond to an XML or
+        JSON file.
+
+    """
+    if not os.path.exists(path):
+        raise InputFormatException(f"Error reading file {path}. "
+                                   "File may not exist.")
+
     if path.endswith('.xml'):
         return _read_from_local_xml(path)
     elif path.endswith('.json'):
-        return _read_from_local_json(path)
+        return _read_from_local_json(service, path)
 
     raise InputFormatException(f'File {path} is not supported. '
                                f'Only .xml and .json are supported.')
 
 
-def _parse_input(input_file):
-    if os.path.exists(input_file):
-        return _read_from_path(input_file)
-
-    raise InputFormatException(f"Error reading file {input_file}. "
-                               f"File may not exist.")
-
-
-def get_dois_from_provider(output_file):
+def get_dois_from_provider(service, prefix, output_file=None):
     """
     Queries the service provider for all the current DOI associated with the
-    PDS-USER account. The server name is fetched from the config file with the
-    'url' field in the service provider grouping.
+    provided prefix.
+
+    Parameters
+    ----------
+    service : str
+        Name of the service provider to pull DOI's from.
+    prefix : str
+        DOI prefix to query for.
+    output_file : str, optional
+        If provided, path to an output file to write the results of the DOI
+        query to.
+
+    Returns
+    -------
+    dois : list of Doi
+        The DOI objects obtained from the service provider.
+    server_url : str
+        The URL of the service provider endpoint. Helpful for logging purposes.
 
     """
-    query_dict = {}
+    if service == SERVICE_TYPE_DATACITE:
+        query_dict = {'doi': f'{prefix}/*'}
+    else:
+        query_dict = {'doi': prefix}
 
-    service_provider = DOIServiceFactory.get_service_type().upper()
+    server_url = m_config.get(service.upper(), 'url')
 
-    o_server_url = m_config.get(service_provider, 'url')
+    logger.info("Using %s server URL %s", service, server_url)
 
-    logger.info("Using %s server URL %s", service_provider, o_server_url)
-
-    web_client = DOIServiceFactory.get_web_client_service()
+    web_client = DOIServiceFactory.get_web_client_service(service)
 
     doi_json = web_client.query_doi(
         query=query_dict, content_type=CONTENT_TYPE_JSON
     )
 
     if output_file:
-        with open(output_file, 'w') as outfile:
-            outfile.write(doi_json)
+        logger.info("Writing query results to %s", output_file)
 
-    web_parser = DOIServiceFactory.get_web_parser_service()
+        with open(output_file, 'w') as outfile:
+            json.dump(json.loads(doi_json), outfile, indent=4)
+
+    web_parser = DOIServiceFactory.get_web_parser_service(service)
 
     dois, _ = web_parser.parse_dois_from_label(
         doi_json, content_type=CONTENT_TYPE_JSON
     )
 
-    return dois, o_server_url
+    return dois, server_url
 
 
 def _get_node_id_from_contributors(doi_fields):
@@ -198,48 +307,60 @@ def _get_node_id_from_contributors(doi_fields):
     Given a doi object, attempt to extract the node_id from contributors field.
     If unable to, return 'eng' as default.
     This function is a one-off as well so no fancy logic.
+
+    Parameters
+    ----------
+    doi_fields : dict
+        DOI metadata fields to obtain PDS node ID from.
+
+    Returns
+    -------
+    node_id : str
+        The three-character PDS identifier determined from the DOI's contributor
+        field.
+
     """
-    o_node_id = 'eng'
+    node_id = 'eng'
 
     if doi_fields.get('contributor'):
         full_name_orig = doi_fields['contributor']
         full_name = full_name_orig.lower()
 
         if 'atmospheres' in full_name:
-            o_node_id = 'atm'
+            node_id = 'atm'
         elif 'engineering' in full_name:
-            o_node_id = 'eng'
+            node_id = 'eng'
         elif 'geosciences' in full_name:
-            o_node_id = 'geo'
+            node_id = 'geo'
         elif 'imaging' in full_name:
-            o_node_id = 'img'
+            node_id = 'img'
         elif 'cartography' in full_name:
-            o_node_id = 'img'
+            node_id = 'img'
         # Some uses title: Navigation and Ancillary Information Facility Node
         # Some uses title: Navigational and Ancillary Information Facility
         # So check for both
         elif 'navigation' in full_name and 'ancillary' in full_name:
-            o_node_id = 'naif'
+            node_id = 'naif'
         elif 'navigational' in full_name and 'ancillary' in full_name:
-            o_node_id = 'naif'
+            node_id = 'naif'
         elif 'plasma' in full_name:
-            o_node_id = 'ppi'
+            node_id = 'ppi'
         elif 'ring' in full_name and 'moon' in full_name:
-            o_node_id = 'rms'
+            node_id = 'rms'
         elif 'small' in full_name or 'bodies' in full_name:
-            o_node_id = 'sbn'
+            node_id = 'sbn'
 
         logger.debug("Derived node ID %s from Contributor field %s",
-                     o_node_id, full_name_orig)
+                     node_id, full_name_orig)
     else:
         logger.warning("No Contributor field available for DOI %s, "
-                       "defaulting to node ID %s", doi_fields['doi'], o_node_id)
+                       "defaulting to node ID %s", doi_fields['doi'], node_id)
 
-    return o_node_id
+    return node_id
 
 
-def perform_import_to_database(db_name, input_source, dry_run, submitter_email,
-                               output_file):
+def perform_import_to_database(service, prefix, db_name, input_source, dry_run,
+                               submitter_email, output_file):
     """
     Imports all records from the input source into a local database.
     The input source may either be an existing file containing DOIs to parse,
@@ -250,6 +371,10 @@ def perform_import_to_database(db_name, input_source, dry_run, submitter_email,
 
     Parameters
     ----------
+    service : str
+        Name of the service provider to import DOI's from.
+    prefix : str
+        DOI prefix value to query for.
     db_name : str
         Name of the database file to import DOI records to.
     input_source : str
@@ -271,60 +396,41 @@ def perform_import_to_database(db_name, input_source, dry_run, submitter_email,
     o_records_written = 0  # Number of records actually written to database
     o_records_dois_skipped = 0  # Number of records skipped due to missing lidvid or invalid prefix
 
-    # If use_doi_filtering_flag is set to True, we will allow only DOIs that
-    # start with the configured PDS DOI token, e.g. '10.17189'.
-    # Servers may contain records other than expected, especially the test
-    # server. For normal operation use_doi_filtering_flag should be set to False.
-    # If set to True, the parameter doi_prefix in config/conf.ini
-    # should be set appropriately.
-    use_doi_filtering_flag = False
+    if not service:
+        service = DOIServiceFactory.get_service_type()
 
-    # If flag skip_db_write_flag set to True, will skip writing of records to
-    # database.  Use by developer to skip database write action.
-    # For normal operation, skip_db_write_flag should be set to False.
-    skip_db_write_flag = False
+    logger.info("Using source service provider %s", service)
 
-    if dry_run:
-        skip_db_write_flag = True
+    if not prefix:
+        prefix = m_config.get(service.upper(), 'doi_prefix')
 
-    o_db_name = db_name
+    logger.info("Using DOI prefix %s", prefix)
 
     # If db_name is not provided, get one from config file:
-    if not o_db_name:
+    if not db_name:
         # This is the local database we'll be writing to
-        o_db_name = m_config.get('OTHER', 'db_file')
+        db_name = m_config.get('OTHER', 'db_file')
 
-    logger.info("Using local database %s", o_db_name)
+    logger.info("Using local database %s", db_name)
 
-    transaction_builder = TransactionBuilder(o_db_name)
+    transaction_builder = TransactionBuilder(db_name)
 
     # If the input is provided, parse from it. Otherwise query the server.
     if input_source:
-        dois = _parse_input(input_source)
-        o_server_url = input_source
+        dois = _read_from_path(service, input_source)
+        server_url = input_source
     else:
         # Get the dois from the server.
-        # Note that because the name of the server is in the config file,
-        # it can be the OPS or TEST server.
-        dois, o_server_url = get_dois_from_provider(output_file)
+        # Note that because the name of the server obtained from the config file,
+        # it could be the OPS or TEST server.
+        dois, server_url = get_dois_from_provider(service, prefix, output_file)
 
     o_records_found = len(dois)
 
-    logger.info("Parsed %d DOI(s) from %s", o_records_found, o_server_url)
+    logger.info("Parsed %d DOI(s) from %s", o_records_found, server_url)
 
     # Write each Doi object as a row into the database.
     for item_index, doi in enumerate(dois):
-        if use_doi_filtering_flag:
-            service_provider = DOIServiceFactory.get_service_type().upper()
-            o_pds_doi_token = m_config.get(service_provider, 'doi_prefix')
-
-            if doi.doi and not doi.doi.startswith(o_pds_doi_token):
-                logger.warning("Skipping non-PDS DOI %s, index %d", doi.doi,
-                               item_index)
-
-                o_records_dois_skipped += 1
-                continue
-
         # If the field 'related_identifier' is None, we cannot proceed since
         # it serves as the primary key for our transaction database.
         if not doi.related_identifier:
@@ -349,13 +455,16 @@ def perform_import_to_database(db_name, input_source, dry_run, submitter_email,
 
         o_records_processed += 1
 
-        if not skip_db_write_flag:
+        if not dry_run:
             # Write a row into the database and save an output label for each
-            # DOI to the local transaction history
+            # DOI to the local transaction history. The format (OSTI vs. Datacite)
+            # of the output label is based on the service provider setting in
+            # the INI config.
             transaction = transaction_builder.prepare_transaction(
                 node_id,
                 submitter_email,
-                doi
+                doi,
+                output_content_type=CONTENT_TYPE_JSON
             )
 
             transaction.log()
@@ -375,6 +484,8 @@ def main():
     parser = create_cmd_parser()
     arguments = parser.parse_args()
 
+    logger.setLevel(logging.INFO)
+
     if arguments.debug:
         logger.setLevel(logging.DEBUG)
 
@@ -385,8 +496,10 @@ def main():
     (records_found,
      records_processed,
      records_written,
-     records_skipped) = perform_import_to_database(arguments.db_name,
-                                                   arguments.input,
+     records_skipped) = perform_import_to_database(arguments.service,
+                                                   arguments.prefix,
+                                                   arguments.db_name,
+                                                   arguments.input_file,
                                                    arguments.dry_run,
                                                    arguments.submitter_email,
                                                    arguments.output_file)


### PR DESCRIPTION
**Summary**
This PR adds the necessary updates to be able to use the `initialize_production_deployment.py` script with both OSTI and DataCite when syncing existing DOI records to a local transaction database.

The script now provides a `--service` flag that can be used to specify the endpoint to pull DOI records from:

```
$ python initialize_production_deployment.py --service osti
INFO __main__:main Starting DOI import to local database...
INFO __main__:perform_import_to_database Using source service provider osti
INFO __main__:perform_import_to_database Using DOI prefix 10.17189
INFO __main__:perform_import_to_database Using local database /Users/collinss/repos/pds-doi-service/venv/doi.db
DEBUG pds_doi_service.core.outputs.service:get_doi_record_service Returning instance of DOIDataCiteRecord for service type datacite
INFO __main__:get_dois_from_provider Using osti server URL https://www.osti.gov/iad2test/api/records
...
INFO __main__:main DOI import complete in 180.94 seconds.
INFO __main__:main Num records found: 8512
INFO __main__:main Num records processed: 8236
INFO __main__:main Num records written: 8236
INFO __main__:main Num records skipped: 276
```

Additionally, the script now also supports a `--prefix` argument to query and sync DOI entries submitted by other PDS nodes:
```
$ python initialize_production_deployment.py --service datacite --prefix 10.26033

INFO __main__:main Starting DOI import to local database...
INFO __main__:perform_import_to_database Using source service provider datacite
INFO __main__:perform_import_to_database Using DOI prefix 10.26033
INFO __main__:perform_import_to_database Using local database /Users/collinss/repos/pds-doi-service/venv/doi.db
DEBUG pds_doi_service.core.outputs.service:get_doi_record_service Returning instance of DOIDataCiteRecord for service type datacite
INFO __main__:get_dois_from_provider Using datacite server URL https://api.datacite.org/dois
DEBUG pds_doi_service.core.outputs.service:get_web_client_service Returning instance of DOIDataCiteWebClient for service type datacite
DEBUG pds_doi_service.core.outputs.datacite.datacite_web_client:query_doi query_string: doi:10.26033/*
...
INFO __main__:main DOI import complete in 3.52 seconds.
INFO __main__:main Num records found: 25
INFO __main__:main Num records processed: 25
INFO __main__:main Num records written: 25
INFO __main__:main Num records skipped: 0
```

Lastly, there have been a number of improvements made to the parsing and generation of DataCite-format labels to better support a range of fields that may be present in labels submitted by other nodes.

**Test Data and/or Report**
Regression tests have been updated where necessary to account for changes made by this PR. No new tests have been added.
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/7139294/test.txt)


**Related Issues**
Resolves #239 
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
->