### PR TITLE
Web Documentation update for v2.0.0

### DIFF
--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -4,25 +4,21 @@
 Quick start
 -----------
 
-Get the code, work on a new branch::
+To obtain a copy of the code and work on a new branch::
 
     git clone https://github.com/NASA-PDS/pds-doi-service.git
-    git checkout -b "#<issue number>"
+    git checkout -b "<issue number>_<issue name>"
 
-Create a virtual environment in ``venv`` using python 3.7 or later::
+Create a virtual environment in ``venv`` using Python 3.9 or later::
 
     python3 -m venv venv
 
-Install dependencies::
+Install the package and its dependencies for development into the virtual environment::
 
-    venv/bin/pip install --requirement requirements.txt
+    pip install --editable '.[dev]'
 
-and make it ready for development::
-
-    venv/bin/pip install --editable .
-
-At this point, we will have the command line tools available in ``venv/bin``
-as explained in usage.
+At this point, the command line tools are now available in ``venv/bin``
+as explained in `usage`_.
 
 .. note::
     "Activating" the virtual environment is deprecated, as per the Python
@@ -33,11 +29,10 @@ as explained in usage.
 Testing
 -------
 
-The code base finally includes unit and integration tests. Once you've built
-out, you can run the unit tests:
+The code base includes both unit and integration tests. Once you've installed
+the service, you can run the unit tests with the following command:
 
-    venv/bin/pip install pytest
-    venv/bin/pytest
+    venv/bin/tox py39
 
 You can run the integration tests with:
 
@@ -47,12 +42,24 @@ You can run the integration tests with:
 Making Releases
 ---------------
 
-The release is done on GitHub and PyPI. This is implemented through the CI/CD framework using GitHub Actions_ on the master branch.
+Releases are done on GitHub and PyPI. This is implemented through the CI/CD
+framework using GitHub Actions_ on the ``main`` branch. To trigger a release
+via the CI/CD framework, create a branch named ``release/<version number>``,
+and push it to the GitHub origin (https://github.com/NASA-PDS/pds-doi-service.git)
+to trigger the Actions_ framework for release, for example::
 
+    git checkout -b release/1.2
+    git push --set-upstream origin release/1.2
+
+From there, the Actions_ framework will determine an appropriate patch version
+number, tag and build a release, and push it to PyPI.
 
 Contribute
 ----------
 
-Fork the code from : https://github.com/NASA-PDS/pds-doi-service and then create a pull request when done.
+Clone the repo from : https://github.com/NASA-PDS/pds-doi-service and then
+submit a pull request for your branch when complete. At least one PDS Engineering
+Node developer must approve the request before it is merged.
 
+.. _usage: ../usage/index.html
 .. _Actions: https://github.com/features/actions

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,15 +2,14 @@ PDS DOI Service
 ===============
 
 The Planetary Data System (PDS_) Digital Object Identifier (DOI_) Service
-enable management of DOIs for PDS with the following operations: reserve,
-draft, release, deactivate.
+enables management of DOIs for PDS with the following operations: list, reserve,
+draft, review, and release.
 
-The PDS DOIs are registered through the `OSTI`_ infrastructure. OSTI registers
-PDS DOI on `DataCite`_ infrastructure.
+The PDS DOIs are registered through the `DataCite`_ infrastructure.
 
-Currently, this service can be deployed as a python package
+Currently, this service is deployed as a Python package
 ``pds-doi-service`` and is executed locally through a command line
-``pds-doi-cmd`` or remotely through a web API server.
+``pds-doi-cmd`` or remotely through the web API server ``pds-doi-api``.
 
 
 .. toctree::
@@ -23,7 +22,6 @@ Currently, this service can be deployed as a python package
    support/index
 
 
-.. _OSTI: https://www.osti.gov/data-services
 .. _dataCite: https://datacite.org
 .. _DOI: https://doi.org/
 .. _PDS: https://pds.nasa.gov/

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -3,7 +3,9 @@
 
 This section describes how to install the PDS DOI Service.
 
-The service is compose by a command line tool and a web API (which enable to activate the command line remotelly or via a web UI)
+The service is composed of a command line tool (``pds-doi-cmd``) and a web API
+(``pds-doi-api``) which provides an interface to the command line that may be
+accessed remotely or via web UI.
 
 
 Requirements
@@ -12,23 +14,23 @@ Requirements
 Prior to installing this software, ensure your system meets the following
 requirements:
 
-•  Python_ 3.7 or above. Python 2 will absolutely *not* work.
+•  Python_ 3.9 or above. Python 2 will absolutely *not* work.
 •  ``libxml2`` version 2.9.2; later 2.9 versions are fine.  Run ``xml2-config
    --version`` to find out.
 
 Consult your operating system instructions or system administrator to install
-the required packages. For those without system administrator access and are
-feeling anxious, you could try a local (home directory) Python_ 3 installation
-using a Miniconda_ installation.
+the required packages. For those without system administrator access, you
+can use a local Python_ 3 installation using a `virtual environment`_
+installation.
 
 
-Doing the Installation
-----------------------
+Installation Instructions
+-------------------------
 
-This setion tells how to do the installation.
+This section documents the installation procedure.
 
-Install
-^^^^^^^
+Installation
+^^^^^^^^^^^^
 
 The easiest way to install this software is to use Pip_, the Python Package
 Installer. If you have Python on your system, you probably already have Pip;
@@ -36,97 +38,119 @@ you can run ``pip3 --help`` to check. Then run::
 
     pip3 install pds-doi-service
 
+..  note::
+
+    The above command will install latest approved release.
+    To install a prior release, you can run::
+
+        pip3 install pds-doi-service==<version>
+
+    The released versions are listed on: https://pypi.org/project/pds-doi-service/#history
+
+    If you want to use the latest unstable version, refer to the `development`_ documentation
+
 If you don't want the package dependencies to interfere with your local system
-you can also use a `virtual environment`_  for your deployment.
+you can use a `virtual environment`_  for your deployment.
 To do so::
 
-    mkdir -p $HOME/.virtualenvs
-    python3 -m venv $HOME/.virtualenvs/pds-doi-service
+    mkdir -p $HOME/.venv
+    python3 -m venv $HOME/.venv/pds-doi-service
     pip3 install pds-doi-service
 
 At this point, the PDS DOI Service commands are available in
-``$HOME/.virtualenvs/pds-doi-service/bin``.
+``$HOME/.venv/pds-doi-service/bin``.
 
 .. note::
     "Activating" the virtual environment is deprecated, as per the Python
     philosophy of "explict > implicit". Instead, invoke the commands directly
-    in ``$HOME/.virtualenvs/pds-doi-service/bin``
+    in ``$HOME/.venv/pds-doi-service/bin``
 
 
+Configuration
+^^^^^^^^^^^^^
+The PDS DOI Service utilizes an INI file for its configuration. While there is a
+default configuration file bundled with the service, it may be superseded by
+a user-provided configuration within the installation directory.
 
-Configure
-^^^^^^^^^
-In the python installation directory, that you can find with command::
+To determine the appropriate location for a user configuration file, run the
+following::
 
     python -c "import sys;print(sys.prefix)"
 
-Create a file ``pds_doi_service.ini``.
+Within the directory returned, create a file named ``pds_doi_service.ini``.
 
-You can override in this file any option set in the file ``pds_doi_service/core/util/conf.ini.default`` found in package.
+In this file you can override any option set in the default configuration file
+``pds_doi_service/core/util/conf.ini.default`` found within the package. An
+example of this file may be found
+`here <https://raw.githubusercontent.com/NASA-PDS/pds-doi-service/main/src/pds_doi_service/core/util/conf.ini.default>`_.
 
-If you want to create production DOIs update the OSTI API server url::
+For example, if you want the service to create production DOIs, update the
+DataCite server url::
 
-   [OSTI]
-    url = https://www.osti.gov/iad2/api/records
+   [DATACITE]
+   url = https://api.datacite.org/dois
 
-You MUST set the OSTI service user and password to be able to reserve or release a DOI::
+In order for the service to do any communication with the DataCite server, You
+**MUST** set the appropriate username and password to be able to reserve or
+release a DOI::
 
-    [OSTI]
+    [DATACITE]
     user = <username>
     password = <password>
 
-Ask the code to pds-operator@jpl.nasa.gov
+Send a request to pds-operator@jpl.nasa.gov if proper credentials are needed.
 
-The tool uses a local database and file system space to store transactions. The default location for these files is the sys.prefix, however it can be updated as follow in the configuration::
+The PDS DOI service uses a local database and file system space to store transactions.
+The default location for these files is the installation location (``sys.prefix``),
+however, it can be updated as follows in the configuration::
 
     [OTHER]
     transaction_dir = <directory absolute path>
     db_file = <database absolute path>/doi.db
 
 
-You can also change the log level by changing the configuration::
+You can also change the logging level by changing the configuration::
 
     [OTHER]
-    logging_level=DEBUG
+    logging_level = DEBUG
 
-Authorized values are DEBUG, INFO, ERROR... (see https://docs.python.org/3/library/logging.html#logging-levels)
+Authorized values are ``DEBUG``, ``INFO``, ``WARNING`` and ``ERROR`` (case-insensitive)...
+(see https://docs.python.org/3/library/logging.html#logging-levels)
 
 
+Running the service via command line tool
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Start using the command line tool
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Once installed, you can run ``pds-doi-cmd --help`` to get a usage message and ensure
+the service is properly installed. You can then consult the `usage`_ documentation
+for more details.
 
-You can then run ``pds-doi-cmd --help`` to get a usage message and ensure
-it's properly installed. You can go to the `usage`_ documentation for details.
 
+Running the service via Web API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can start the web API service with command line ``pds-doi-api``.
+
+You can explore the API documentation and test it using its built-in Swagger UI.
+To access the test UI, navigate to http://localhost:8080/PDS_APIs/pds_doi_api/0.2/ui/
+using a web-browser on the same machine that is running the API service.
 
 ..  note::
 
-    The above commands will install last approved release.
-    To install former releases, you can do:
+    In order to access the built-in Swagger UI, there must **not** be any value
+    set for the ``OTHER.api_valid_referrers`` section of the INI config. To
+    ensure the value is not set, add the following the user configuration file
+    described in the Configuration section above::
 
-    pip install pds-doi-core==<version>
-
-    The released versions are listed on: https://pypi.org/project/pds-doi-core/#history
-
-    If you want to use the latest unstable version, you can refer to the `development`_ documentation
-
-
-Start the API server
-^^^^^^^^^^^^^^^^^^^^
-
-You can simply start the web API  service with command line ``pds-doi-api``.
-
-You can explore the API documentation and test it from its UI: http://localhost:8080/PDS_APIs/pds_doi_api/0.1/ui/
+        [OTHER]
+        api_valid_referrers =
 
 
+Upgrading the Service
+---------------------
 
-
-Upgrade Software
-----------------
-
-To check and install an upgrade to the software, run the following command in your
-virtual environment::
+To check for and install an upgrade to the service, run the following command in
+your virtual environment::
 
   pip install --upgrade pds-doi-service
 

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -7,33 +7,47 @@
 Overview
 --------
 
-A DOI (Digital Object Identifier) is a URI which is used to permanently identify a digital object: dataset or document.
+A DOI (Digital Object Identifier) is a URI which is used to permanently identify
+a digital object, typically a dataset or document.
 The DOI is then used to cite the digital object, especially in scientific papers.
 
-In the context of PDS, the DOIs follows this workflow:
-- reserve: before a dataset is published in PDS, a DOI can be reserved so that the researchers working with the digital resource at early stage can cite it in their papers. This step is optional.
-- draft: the metadata associated to the DOI is elaborated and validated.
-- release: the offcial DOI is registered at `OSTI`_ and `dataCite`_.
-- deactivate (To Be Done): although it is not supposed to happen, due to error in the release one might deactivate a  DOI.
+In the context of PDS, publishing a new DOI follows this workflow:
 
-The reserve, draft and release steps can be repeated multiple time to update a DOI metadata.
+    - `Reserve`: Before a dataset is published in PDS, a DOI is reserved so the
+      researchers working with the digital resource can cite it at early stage.
+    - `Draft`: The metadata associated to an existing DOI is elaborated and validated.
+    - `Review`: Once all metadata has been properly associated to the DOI, the
+      requester submits the DOI record for review to the PDS Engineering node.
+    - `Release`: After the PDS Engineering node determines that the DOI record is
+      filled out properly, the DOI and its metadata is officially registered at
+      `DataCite`_ and made available for public discovery. If there any issues with
+      the reviewed record, PDS Engineering node may move the record back to `Draft`
+      status for correction by the original submitter.
 
-The inputs to the DOI creation are either PDS4 labels or ad hoc spreadsheets (for the reserve step).
+The Draft and Release steps may be repeated multiple times to update the metadata
+associated to the DOI.
 
-The metadata managed with DOIs is meant to be preserved and traceable as it is used to permanently cite a digital resource.
-For this reason all the transactions, creations, updates with the PDS DOI management system are registered in a database.
+Inputs to DOI creation (the Reserve step) are either PDS4 labels or ad-hoc
+spreadsheets.
 
-Currently the tool provided is activated with a command line and used by a PDS Engineering Node operator interacting with the Discipline Nodes.
-A later version will provide a web API, a web UI and a cmd API client to enable Discipline Nodes to directly manage their DOIs.
+The metadata managed with DOIs is meant to be preserved and traceable, as it is
+used to permanently cite a digital resource. For this reason, all transactions,
+creations, and updates with the PDS DOI Service are registered in a local database.
+This database is used to track submissions-in-progress and help ensure the proper
+workflow (`Reserve` -> `Draft` -> `Review` -> `Release`) is enforced.
 
-Usage Information
------------------
+Currently, the service provides a command line tool for use by a PDS Engineering
+Node operator interacting with the Discipline Nodes, as well as a web API and UI
+to enable Discipline Nodes to directly manage their DOIs.
+
+Command Line Usage Information
+------------------------------
 
 .. argparse::
-   :module: pds_doi_service.core.actions
+   :module: pds_doi_service.core.actions.action
    :func: create_parser
    :prog: pds-doi-cmd
 
 
 .. _OSTI: https://www.osti.gov/data-services
-.. _dataCite: https://datacite.org
+.. _DataCite: https://datacite.org


### PR DESCRIPTION

## 🗒️ Summary
This branch updates the web documentation .rst files for the pds-doi-service to be in line with its current state in release v2.0.0.

## ⚙️ Test Data and/or Report
I was able to successfully compile the docs via `tox docs` (although this still seemed to run the `py39` and `lint` stages anyway 🤷 ). I was also able to confirm that the sphinx argparse directive for the command-line tool was pulled into the usage page as expected.
Sample docs can be viewed here: 
[pds-doi-service-docs-2.0.0.zip](https://github.com/NASA-PDS/pds-doi-service/files/7246720/pds-doi-service-docs-2.0.0.zip)


## ♻️ Related Issues
#253 
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


