### PR TITLE
DataCite Query Pagination Support

### DIFF
--- a/src/pds_doi_service/core/entities/doi.py
+++ b/src/pds_doi_service/core/entities/doi.py
@@ -109,7 +109,7 @@ class Doi:
     product_type_specific: str
     related_identifier: str
     identifiers: list[str] = field(default_factory=list)
-    authors: Optional[list[str]] = None
+    authors: Optional[list[dict]] = None
     keywords: set[str] = field(default_factory=set)
     editors: Optional[list[str]] = None
     description: Optional[str] = None

--- a/src/pds_doi_service/core/input/node_util.py
+++ b/src/pds_doi_service/core/input/node_util.py
@@ -1,16 +1,15 @@
-#!/bin/python
 #
 #  Copyright 2020, by the California Institute of Technology.  ALL RIGHTS
 #  RESERVED. United States Government Sponsorship acknowledged. Any commercial
 #  use must be negotiated with the Office of Technology Transfer at the
 #  California Institute of Technology.
 #
-# ------------------------------
+
 from pds_doi_service.core.input.exceptions import UnknownNodeException
 from pds_doi_service.core.util.general_util import get_logger
 
 # Get the common logger and set the level for this file.
-logger = get_logger("pds_doi_core.input.node_util")
+logger = get_logger(__name__)
 
 
 class NodeUtil:
@@ -23,6 +22,7 @@ class NodeUtil:
         "IMG": "Cartography and Imaging Sciences Discipline",
         "NAIF": "Navigational and Ancillary Information Facility",
         "PPI": "Planetary Plasma Interactions",
+        "RS": "Radio Science",
         "RMS": "Ring-Moon Systems",
         "SBN": "Small Bodies",
     }
@@ -40,8 +40,3 @@ class NodeUtil:
     @classmethod
     def get_permissible_values(cls):
         return [c.lower() for c in cls.m_node_id_dict.keys()]
-
-
-#    @classmethod
-#    def get_keys(cls):
-#        return [c.lower() for c in cls.m_node_id_dict.keys()]


### PR DESCRIPTION
## 🗒️ Summary
This PR adds support for DataCite's pagination scheme to the query function used to pull down existing DOI records from a DataCite server. This functionality should have been included with the original addition of DataCite support, but was overlooked.

In addition to pagination support, this branch adds several other small improvements, including:

- Addition of "Radio Science" node ID to available PDS Node ID's recognized by DOI service
- Better logging of warning messages from parsing of optional fields from a DataCite label
- Better support for determining an appropriate node ID from a parsed DataCite label when importing to the local database

## ⚙️ Test Data and/or Report
One of the following should be included here:
A unit test has been added for the pagination support added to the DataCite web client.
[test.txt](https://github.com/NASA-PDS/pds-doi-service/files/7281829/test.txt)


## ♻️ Related Issues
Fixes #261 
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


