### PR TITLE
Label Format Output for List Action

### DIFF
--- a/src/pds_doi_service/core/actions/test/list_test.py
+++ b/src/pds_doi_service/core/actions/test/list_test.py
@@ -10,6 +10,8 @@ from unittest.mock import patch
 import pds_doi_service.core.outputs.datacite.datacite_web_client
 import pds_doi_service.core.outputs.osti.osti_web_client
 from pds_doi_service.core.actions.list import DOICoreActionList
+from pds_doi_service.core.actions.list import FORMAT_LABEL
+from pds_doi_service.core.actions.list import FORMAT_RECORD
 from pds_doi_service.core.actions.release import DOICoreActionRelease
 from pds_doi_service.core.actions.reserve import DOICoreActionReserve
 from pds_doi_service.core.entities.doi import DoiStatus
@@ -149,8 +151,24 @@ class ListActionTestCase(unittest.TestCase):
         self.assertEqual(list_result["subtype"], doi.product_type_specific)
         self.assertEqual(list_result["identifier"], doi.pds_identifier)
 
+        # Run the same query again using the label format
+        list_kwargs = {"status": DoiStatus.Review, "format": FORMAT_LABEL}
+
+        list_result = self._list_action.run(**list_kwargs)
+
+        dois, _ = self._web_parser.parse_dois_from_label(list_result)
+
+        self.assertEqual(len(dois), 1)
+
+        output_doi = dois[0]
+
+        self.assertEqual(doi.pds_identifier, output_doi.pds_identifier)
+        self.assertEqual(doi.title, output_doi.title)
+        self.assertEqual(doi.doi, output_doi.doi)
+        self.assertEqual(doi.status, output_doi.status)
+
         # Finally, query for draft status again, should get no results back
-        list_kwargs = {"status": DoiStatus.Draft}
+        list_kwargs = {"status": DoiStatus.Draft, "format": FORMAT_RECORD}
 
         list_result = json.loads(self._list_action.run(**list_kwargs))
 


### PR DESCRIPTION
## 🗒️ Summary
Small update to add an option to the list action that returns the results of the query as a combined JSON label. This allows a user to obtain label entries for queried DOI records directly, without the need to interact with the local transaction history store.

## ⚙️ Test Data and/or Report
Updated unit tests for list action to exercise the new label format feature.
[tox.log](https://github.com/NASA-PDS/pds-doi-service/files/7471320/tox.log)


## ♻️ Related Issues
Resolves #289 
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


