### PR TITLE
Global Keywords Handling Fix

### DIFF
--- a/src/pds_doi_service/core/actions/release.py
+++ b/src/pds_doi_service/core/actions/release.py
@@ -30,6 +30,7 @@ from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_JSON
 from pds_doi_service.core.outputs.doi_validator import DOIValidator
 from pds_doi_service.core.outputs.service import DOIServiceFactory
 from pds_doi_service.core.util.general_util import create_landing_page_url
+from pds_doi_service.core.util.general_util import get_global_keywords
 from pds_doi_service.core.util.general_util import get_logger
 from pds_doi_service.core.util.node_util import NodeUtil
 
@@ -144,6 +145,9 @@ class DOICoreActionRelease(DOICoreAction):
             # Make sure correct contributor and publisher fields are set
             doi.contributor = NodeUtil().get_node_long_name(self._node)
             doi.publisher = self._config.get("OTHER", "doi_publisher")
+
+            # Make sure the global keywords from the config are included
+            doi.keywords.update(get_global_keywords())
 
             # Add 'status' field so the ranking in the workflow can be determined.
             if self._review:

--- a/src/pds_doi_service/core/actions/reserve.py
+++ b/src/pds_doi_service/core/actions/reserve.py
@@ -28,6 +28,7 @@ from pds_doi_service.core.input.input_util import DOIInputUtil
 from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_JSON
 from pds_doi_service.core.outputs.doi_validator import DOIValidator
 from pds_doi_service.core.outputs.service import DOIServiceFactory
+from pds_doi_service.core.util.general_util import get_global_keywords
 from pds_doi_service.core.util.general_util import get_logger
 from pds_doi_service.core.util.node_util import NodeUtil
 
@@ -139,6 +140,9 @@ class DOICoreActionReserve(DOICoreAction):
 
             # Add 'status' field so the ranking in the workflow can be determined
             doi.status = DoiStatus.Draft
+
+            # Make sure the global keywords from the config are included
+            doi.keywords.update(get_global_keywords())
 
             # Add the event field to instruct DataCite to make this entry
             # hidden so it can be modified (should have no effect for other

--- a/src/pds_doi_service/core/actions/test/release_test.py
+++ b/src/pds_doi_service/core/actions/test/release_test.py
@@ -14,6 +14,7 @@ from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_JSON
 from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_XML
 from pds_doi_service.core.outputs.service import DOIServiceFactory
 from pds_doi_service.core.outputs.web_client import WEB_METHOD_POST
+from pds_doi_service.core.util.general_util import get_global_keywords
 from pkg_resources import resource_filename
 
 
@@ -110,6 +111,9 @@ class ReleaseActionTestCase(unittest.TestCase):
 
             # There should always be a DOI assigned, for both review and full-release
             self.assertIsNotNone(doi.doi)
+
+            # Make sure global keywords were assigned at some point in the process
+            self.assertTrue(all(keyword in doi.keywords for keyword in get_global_keywords()))
 
     def test_reserve_release_to_review(self):
         """Test release to review status with a reserved DOI entry"""

--- a/src/pds_doi_service/core/actions/test/reserve_test.py
+++ b/src/pds_doi_service/core/actions/test/reserve_test.py
@@ -15,6 +15,7 @@ from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_JSON
 from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_XML
 from pds_doi_service.core.outputs.service import DOIServiceFactory
 from pds_doi_service.core.outputs.web_client import WEB_METHOD_POST
+from pds_doi_service.core.util.general_util import get_global_keywords
 from pkg_resources import resource_filename
 
 
@@ -203,9 +204,10 @@ class ReserveActionTestCase(unittest.TestCase):
 
         self.assertEqual(len(doi.authors), 4)
         self.assertEqual(len(doi.editors), 3)
-        self.assertEqual(len(doi.keywords), 15)
+        self.assertEqual(len(doi.keywords), 17)
         self.assertEqual(doi.pds_identifier, "urn:nasa:pds:insight_cameras::1.0")
         self.assertEqual(doi.product_type, ProductType.Collection)
+        self.assertTrue(all(keyword in doi.keywords for keyword in get_global_keywords()))
         self.assertIsInstance(doi.publication_date, datetime)
         self.assertIsInstance(doi.date_record_added, datetime)
 
@@ -232,10 +234,11 @@ class ReserveActionTestCase(unittest.TestCase):
 
         for doi in dois:
             self.assertEqual(len(doi.authors), 4)
-            self.assertEqual(len(doi.keywords), 15)
+            self.assertEqual(len(doi.keywords), 17)
             self.assertEqual(doi.product_type, ProductType.Collection)
             self.assertIsInstance(doi.publication_date, datetime)
             self.assertIsInstance(doi.date_record_added, datetime)
+            self.assertTrue(all(keyword in doi.keywords for keyword in get_global_keywords()))
             self.assertTrue(doi.pds_identifier.startswith("urn:nasa:pds:insight_cameras::1"))
             self.assertTrue(doi.title.startswith("InSight Cameras Bundle 1."))
 
@@ -271,7 +274,8 @@ class ReserveActionTestCase(unittest.TestCase):
         doi = dois[0]
 
         self.assertEqual(len(doi.authors), 4)
-        self.assertEqual(len(doi.keywords), 15)
+        self.assertEqual(len(doi.keywords), 17)
+        self.assertTrue(all(keyword in doi.keywords for keyword in get_global_keywords()))
         self.assertEqual(doi.pds_identifier, "urn:nasa:pds:insight_cameras::1.0")
         self.assertEqual(doi.product_type, ProductType.Collection)
         self.assertIsInstance(doi.publication_date, datetime)
@@ -301,9 +305,10 @@ class ReserveActionTestCase(unittest.TestCase):
         doi = dois[0]
 
         self.assertEqual(len(doi.authors), 4)
-        self.assertEqual(len(doi.keywords), 9)
+        self.assertEqual(len(doi.keywords), 11)
         self.assertEqual(doi.pds_identifier, "urn:nasa:pds:insight_cameras:data::1.0")
         self.assertEqual(doi.product_type, ProductType.Collection)
+        self.assertTrue(all(keyword in doi.keywords for keyword in get_global_keywords()))
         self.assertIsInstance(doi.publication_date, datetime)
         self.assertIsInstance(doi.date_record_added, datetime)
 
@@ -331,10 +336,11 @@ class ReserveActionTestCase(unittest.TestCase):
         doi = dois[0]
 
         self.assertEqual(len(doi.authors), 4)
-        self.assertEqual(len(doi.keywords), 9)
+        self.assertEqual(len(doi.keywords), 11)
         self.assertEqual(doi.pds_identifier, "urn:nasa:pds:insight_cameras:browse::1.0")
         self.assertEqual(doi.description, "Collection of BROWSE products.")
         self.assertEqual(doi.product_type, ProductType.Collection)
+        self.assertTrue(all(keyword in doi.keywords for keyword in get_global_keywords()))
         self.assertIsInstance(doi.publication_date, datetime)
         self.assertIsInstance(doi.date_record_added, datetime)
 
@@ -362,10 +368,11 @@ class ReserveActionTestCase(unittest.TestCase):
         doi = dois[0]
 
         self.assertEqual(len(doi.authors), 4)
-        self.assertEqual(len(doi.keywords), 11)
+        self.assertEqual(len(doi.keywords), 13)
         self.assertEqual(doi.pds_identifier, "urn:nasa:pds:insight_cameras:calibration::1.0")
         self.assertEqual(doi.description, "Collection of CALIBRATION files/products to include in the archive.")
         self.assertEqual(doi.product_type, ProductType.Collection)
+        self.assertTrue(all(keyword in doi.keywords for keyword in get_global_keywords()))
         self.assertIsInstance(doi.publication_date, datetime)
         self.assertIsInstance(doi.date_record_added, datetime)
 
@@ -393,10 +400,11 @@ class ReserveActionTestCase(unittest.TestCase):
         doi = dois[0]
 
         self.assertEqual(len(doi.authors), 4)
-        self.assertEqual(len(doi.keywords), 9)
+        self.assertEqual(len(doi.keywords), 11)
         self.assertEqual(doi.pds_identifier, "urn:nasa:pds:insight_cameras:document::1.0")
         self.assertEqual(doi.description, "Collection of DOCUMENT products.")
         self.assertEqual(doi.product_type, ProductType.Collection)
+        self.assertTrue(all(keyword in doi.keywords for keyword in get_global_keywords()))
         self.assertIsInstance(doi.publication_date, datetime)
         self.assertIsInstance(doi.date_record_added, datetime)
 

--- a/src/pds_doi_service/core/actions/test/update_test.py
+++ b/src/pds_doi_service/core/actions/test/update_test.py
@@ -20,6 +20,7 @@ from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_XML
 from pds_doi_service.core.outputs.service import DOIServiceFactory
 from pds_doi_service.core.outputs.web_client import WEB_METHOD_POST
 from pds_doi_service.core.util.general_util import create_landing_page_url
+from pds_doi_service.core.util.general_util import get_global_keywords
 from pkg_resources import resource_filename
 
 
@@ -164,6 +165,9 @@ class UpdateActionTestCase(unittest.TestCase):
         self.assertIn("urn:nasa:pds:insight_cameras::2.0", related_identifiers)
         self.assertIn("urn:nasa:pds:insight_cameras::1.0", related_identifiers)
 
+        # Global keywords should have been assigned, if they weren't already
+        self.assertTrue(all(keyword in updated_doi.keywords for keyword in get_global_keywords()))
+
     @patch.object(
         pds_doi_service.core.outputs.datacite.datacite_web_client.DOIDataCiteWebClient,
         "submit_content",
@@ -229,10 +233,11 @@ class UpdateActionTestCase(unittest.TestCase):
         self.assertEqual(len(dois), 3)
         self.assertEqual(len(errors), 0)
 
-        # Make sure the identifiers were updated as expected and the site urls assigned
+        # Make sure the identifiers were updated as expected, the site url is assigned, and global keywords were added
         for doi in updated_dois:
             self.assertTrue(doi.pds_identifier.endswith(".99"))
             self.assertIsNotNone(doi.site_url)
+            self.assertTrue(all(keyword in doi.keywords for keyword in get_global_keywords()))
 
     @patch.object(
         pds_doi_service.core.outputs.datacite.datacite_web_client.DOIDataCiteWebClient,
@@ -314,6 +319,9 @@ class UpdateActionTestCase(unittest.TestCase):
         )
         self.assertIn("urn:nasa:pds:new_insight_cameras::1.0", related_identifiers)
         self.assertIn("urn:nasa:pds:insight_cameras::1.0", related_identifiers)
+
+        # Global keywords should have been assigned, if they weren't already
+        self.assertTrue(all(keyword in updated_doi.keywords for keyword in get_global_keywords()))
 
     def test_invalid_update_requests(self):
         """Test invalid update requests to ensure exceptions are raised"""

--- a/src/pds_doi_service/core/actions/update.py
+++ b/src/pds_doi_service/core/actions/update.py
@@ -28,6 +28,7 @@ from pds_doi_service.core.input.input_util import DOIInputUtil
 from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_JSON
 from pds_doi_service.core.outputs.doi_validator import DOIValidator
 from pds_doi_service.core.outputs.service import DOIServiceFactory
+from pds_doi_service.core.util.general_util import get_global_keywords
 from pds_doi_service.core.util.general_util import get_logger
 from pds_doi_service.core.util.node_util import NodeUtil
 
@@ -178,6 +179,9 @@ class DOICoreActionUpdate(DOICoreAction):
 
             # Store the previous status of this DOI
             doi.previous_status = doi.status
+
+            # Make sure the global keywords from the config are included
+            doi.keywords.update(get_global_keywords())
 
             # If this DOI has already been released (aka is findable or in review),
             # then move the status back to the Review step. Otherwise, the record

--- a/src/pds_doi_service/core/entities/doi.py
+++ b/src/pds_doi_service/core/entities/doi.py
@@ -18,6 +18,8 @@ from enum import Enum
 from enum import unique
 from typing import Optional
 
+from pds_doi_service.core.util.general_util import get_global_keywords
+
 
 @unique
 class ProductType(str, Enum):
@@ -111,7 +113,7 @@ class Doi:
     identifiers: list[dict] = field(default_factory=list)
     related_identifiers: list[dict] = field(default_factory=list)
     authors: Optional[list[dict]] = None
-    keywords: set[str] = field(default_factory=set)
+    keywords: set[str] = field(default_factory=get_global_keywords)
     editors: Optional[list[dict]] = None
     description: Optional[str] = None
     id: Optional[str] = None

--- a/src/pds_doi_service/core/util/general_util.py
+++ b/src/pds_doi_service/core/util/general_util.py
@@ -207,6 +207,42 @@ def create_landing_page_url(identifier, product_type):
     return site_url
 
 
+def get_global_keywords():
+    """
+    Returns the global keywords (which should get assigned to each Doi object)
+    from the INI config as a set.
+
+    Returns
+    -------
+    global_keywords : set
+        The set of global keywords as parsed from the INI. Any leading/trailing
+        whitespace is removed from each keyword once its been parsed.
+
+    """
+    config = DOIConfigUtil().get_config()
+
+    global_keyword_values = config.get("OTHER", "global_keyword_values")
+
+    # Some older versions of the INI config delimited keywords by semi-colon,
+    # so replace with comma here
+    global_keyword_values = global_keyword_values.replace(";", ",")
+
+    # Parse keywords into list
+    global_keyword_list = global_keyword_values.split(",")
+
+    # Convert all values to string, if for whatever reason a number is being used as a keyword
+    global_keyword_list = map(str, global_keyword_list)
+
+    # Sanitize any leading/trailing whitespace, then convert to a set
+    global_keyword_set = set(map(str.strip, global_keyword_list))
+
+    # It's possible for the empty string to sneak in in certain circumstances,
+    # (trailing comma/semi-colon) so manually remove it, if present
+    global_keyword_set.discard("")
+
+    return global_keyword_set
+
+
 def sanitize_json_string(string):
     """
     Cleans up extraneous whitespace from the provided string so it may be


### PR DESCRIPTION
## 🗒️ Summary
This PR fixes handling of the global keywords assigned within the INI config to ensure that said keywords are always included with any `Doi` object handled by the reserve, update or release actions.

## ⚙️ Test Data and/or Report
Unit tests have been added for the new global keyword parsing function, and existing tests for the reserve, update and release actions have been updated to ensure global keywords are always added.
[tox.log](https://github.com/NASA-PDS/pds-doi-service/files/7508247/tox.log)


## ♻️ Related Issues
Fixes #273
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


