### PR TITLE
Case-Insensitve Wildcard Matching for DB Queries

### DIFF
--- a/src/pds_doi_service/core/db/test/doi_database_test.py
+++ b/src/pds_doi_service/core/db/test/doi_database_test.py
@@ -280,6 +280,22 @@ class DOIDatabaseTest(unittest.TestCase):
 
         self.assertEqual(len(o_query_result[-1]), 2)
 
+        # Test case-insensitive search of titles
+        o_query_result = self._doi_database.select_latest_rows(
+            query_criterias={"title": ["*shocked feldspars bundle ?"]}
+        )
+
+        # Should get all rows back
+        self.assertEqual(len(o_query_result[-1]), num_rows)
+
+        # Test combination of wildcard tokens on a DOI search
+        o_query_result = self._doi_database.select_latest_rows(
+            query_criterias={"doi": ["10.17189/?0001", "10.1718*/20003"]}
+        )
+
+        # Should only match two DOI's
+        self.assertEqual(len(o_query_result[-1]), 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 🗒️ Summary
Small update to DOI transaction database code to convert usage of `GLOB` SQLite statement to `LIKE` so wildcard searches are case-insensitive by default.

## ⚙️ Test Data and/or Report
Added unit tests to existing suite to test case-insensitive wildcard search
[tox.log](https://github.com/NASA-PDS/pds-doi-service/files/7522774/tox.log)


## ♻️ Related Issues
Resolves #223 
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


