### PR TITLE
Add coverage testing and reporting to SonarQube Cloud

### DIFF
--- a/.github/workflows/unstable-cicd.yaml
+++ b/.github/workflows/unstable-cicd.yaml
@@ -91,6 +91,12 @@ jobs:
                     ADMIN_GITHUB_TOKEN: ${{secrets.ADMIN_GITHUB_TOKEN}}
                     DATACITE_USER: ${{secrets.DATACITE_USER}}
                     DATACITE_PASSWORD: ${{secrets.DATACITE_PASSWORD}}
+            -
+                name: 🛏️ Upload Coverage
+                uses: SonarSource/sonarqube-scan-action@v5
+                env:
+                    SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
+
 
 ...
 # -*- mode: yaml; indent: 4; fill-column: 120; coding: utf-8 -*-

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ pip-selfcheck.json
 
 # Python testing artifacts
 .coverage
+coverage.xml
 htmlcov
 .tox/
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,3 @@
+sonar.projectKey=NASA-PDS_doi-service
+sonar.organization=nasa-pds
+sonar.python.coverage.reportPaths=coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,42 @@
 [tox]
 envlist = py313, docs, lint
+requires = tox>=4.6
 
 [testenv]
-deps = .[dev]
-allowlist_externals = pytest
-commands = pytest src tests
-passenv =
-    CI
-    DATACITE_USER
-    DATACITE_PASSWORD
+description = run tests
+basepython = python3.13
+package = wheel
+extras = dev
+usedevelop = true
+commands = pytest --cov=src --cov-report=xml {posargs}
 
 [testenv:docs]
-deps = .[dev]
-allowlist_externals = python
+description = build docs
+extras = dev
 commands = sphinx-build -b html docs/source docs/build
 
 [testenv:lint]
-deps = pre-commit
-commands=
-    python -m pre_commit run --color=always {posargs:--all}
+description = run linters
 skip_install = true
+deps = pre-commit
+commands = python -m pre_commit run --color=always {posargs:--all}
 
-[testenv:dev]
-basepython = python3.13
-usedevelop = True
-deps = .[dev]
+[coverage:run]
+source = src
+omit =
+    */tests/*
+    */test_*
+    */__pycache__/*
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
+    class .*\bProtocol\):
+    @(abc\.)?abstractmethod


### PR DESCRIPTION
## 🗒️ Summary

Merge to add coverage testing and reporting to SonarQube Cloud

## ⚙️ Test Data and/or Report

A little taste from `coverage.xml`:
```xml
<?xml version="1.0" ?>
<coverage version="7.6.12" timestamp="1759585151124" lines-valid="6454" lines-covered="5345" line-rate="0.8282" branches-covered="0" branches-valid="0" branch-rate="0" complexity="0">
        <!-- Generated by coverage.py: https://coverage.readthedocs.io/en/7.6.12 -->
        <!-- Based on https://raw.githubusercontent.com/cobertura/web/master/htdocs/xml/coverage-04.dtd -->
        <sources>
                <source>/Users/kelly/Documents/Clients/JPL/PDS/Development/nasa-pds/doi-service/src</source>
        </sources>
        <packages>
                <package name="pds_doi_service" line-rate="0.1111" branch-rate="0" complexity="0">
                        <classes>

…
```

## ♻️ Related Issues

- https://github.com/NASA-PDS/template-repo-python/issues/104