### PR TITLE
Fix FIPS compliance for checksum() function

### DIFF
--- a/src/pds_doi_service/core/util/general_util.py
+++ b/src/pds_doi_service/core/util/general_util.py
@@ -45,7 +45,7 @@ def checksum(record_payload):
         The hex digest of the md5 checksum.
 
     """
-    md5 = hashlib.md5()
+    md5 = hashlib.md5(usedforsecurity=False)
     md5.update(record_payload.encode())
     return md5.hexdigest()
 


### PR DESCRIPTION
## Summary

- Adds `usedforsecurity=False` parameter to `hashlib.md5()` call in the `checksum()` function
- Enables the DOI service to operate on FIPS-enabled systems
- Follows the same approach used in PR #495 for NLTK FIPS compatibility

## Problem

Issue #493 and PR #495 addressed FIPS compliance for NLTK's MD5 usage, but the DOI service's own `checksum()` function in `general_util.py` was not updated. This caused `pds-doi-init` to fail on FIPS-enabled systems with:

```
ValueError: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS
```

## Solution

The `checksum()` function is only used for data integrity checking (comparing DOI record content in `transaction.py:123` to detect changes before committing), not for cryptographic security purposes. Therefore, the `usedforsecurity=False` flag is appropriate and allows the code to run in FIPS mode.

## Test Plan

- [x] Pre-commit hooks pass (flake8, imports, secrets detection)
- [x] Direct testing confirms MD5 function works with the parameter
- [x] CI tests pass
- [x] Verify `pds-doi-init` works on FIPS-enabled system

## Related Issues

Fixes #497
Related to #493, #495